### PR TITLE
Added baseURL to options when using as node module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 const {app, server} = require('./src/server/app');
 
-module.exports = function(config, disableListen) {
+module.exports = function(config, options) {
+  options = typeof options == 'boolean' ? { disableListen: options } : options;
+  const { disableListen, baseURL } = options;
+
   app.set('bull config', config);
+  app.set('baseURL', (baseURL || ''));
 
   if (disableListen) server.close();
 

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3,6 +3,8 @@ $(document).ready(() => {
     return string.charAt(0).toUpperCase() + string.slice(1);
   }
 
+  const baseURL = $('body').data('baseUrl')
+
   // Set up individual "retry job" handler
   $('.js-retry-job').on('click', function(e) {
     e.preventDefault();
@@ -16,7 +18,7 @@ $(document).ready(() => {
     if (r) {
       $.ajax({
         method: 'PATCH',
-        url: `/api/queue/${encodeURIComponent(queueHost)}/${encodeURIComponent(queueName)}/job/${encodeURIComponent(jobId)}`
+        url: `${baseURL}/api/queue/${encodeURIComponent(queueHost)}/${encodeURIComponent(queueName)}/job/${encodeURIComponent(jobId)}`
       }).done(() => {
         window.location.reload();
       }).fail((jqXHR) => {
@@ -42,9 +44,9 @@ $(document).ready(() => {
     if (r) {
       $.ajax({
         method: 'DELETE',
-        url: `/api/queue/${encodeURIComponent(queueHost)}/${encodeURIComponent(queueName)}/job/${encodeURIComponent(jobId)}`
+        url: `${baseURL}/api/queue/${encodeURIComponent(queueHost)}/${encodeURIComponent(queueName)}/job/${encodeURIComponent(jobId)}`
       }).done(() => {
-        window.location.href = `/dashboard/${encodeURIComponent(queueHost)}/${encodeURIComponent(queueName)}/${jobState}`;
+        window.location.href = `${baseURL}/dashboard/${encodeURIComponent(queueHost)}/${encodeURIComponent(queueName)}/${jobState}`;
       }).fail((jqXHR) => {
         window.alert(`Request failed, check console for error.`);
         console.error(jqXHR.responseText);
@@ -114,7 +116,7 @@ $(document).ready(() => {
     if (r) {
       $.ajax({
         method: action === 'remove' ? 'POST' : 'PATCH',
-        url: `/api/queue/${encodeURIComponent(queueHost)}/${encodeURIComponent(queueName)}/job/bulk`,
+        url: `${baseURL}/api/queue/${encodeURIComponent(queueHost)}/${encodeURIComponent(queueName)}/job/bulk`,
         data: JSON.stringify(data),
         contentType: 'application/json'
       }).done(() => {
@@ -126,5 +128,5 @@ $(document).ready(() => {
     } else {
       $(this).prop('disabled', false);
     }
-  });  
+  });
 });

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -20,7 +20,8 @@ app.set('json spaces', 2);
 
 app.engine('hbs', hbs.express4({
   defaultLayout: `${__dirname}/views/layout.hbs`,
-  partialsDir: `${__dirname}/views/partials`
+  partialsDir: `${__dirname}/views/partials`,
+  templateOptions: { baseURL: app.get('baseURL') }
 }));
 
 app.use(express.static(path.join(__dirname, '/../../public')));

--- a/src/server/views/dashboard/jobDetails.js
+++ b/src/server/views/dashboard/jobDetails.js
@@ -10,6 +10,8 @@ async function handler(req, res) {
   const queue = await Queues.get(queueName, queueHost);
   if (!queue) return res.status(404).render('dashboard/templates/queueNotFound.hbs', {queueName, queueHost});
 
+  const baseURL = req.app.get('baseURL');
+
   const job = await queue.getJob(id);
   if (!job) return res.status(404).render('dashboard/templates/jobNotFound.hbs', {id, queueName, queueHost});
 
@@ -24,6 +26,7 @@ async function handler(req, res) {
     queueName,
     queueHost,
     jobState,
+    baseURL,
     job
   });
 }

--- a/src/server/views/dashboard/queueDetails.js
+++ b/src/server/views/dashboard/queueDetails.js
@@ -10,11 +10,13 @@ async function handler(req, res) {
 
   const jobCounts = await queue.getJobCounts(queue);
   const stats = await QueueHelpers.getStats(queue);
+  const baseURL = req.app.get('baseURL');
 
   return res.render('dashboard/templates/queueDetails.hbs', {
     queueName,
     queueHost,
     jobCounts,
+    baseURL,
     stats
   });
 }

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -20,6 +20,8 @@ async function handler(req, res) {
   const endId = startId + pageSize - 1;
   const jobs = await queue[`get${_.capitalize(state)}`](startId, endId);
 
+  const baseURL = req.app.get('baseURL');
+
   let pages = _.range(page - 6, page + 7)
     .filter((page) => page >= 1);
   while (pages.length < 12) {
@@ -30,6 +32,7 @@ async function handler(req, res) {
   return res.render('dashboard/templates/queueJobsByState.hbs', {
     queueName,
     queueHost,
+    baseURL,
     state,
     jobs,
     jobsInStateCount: jobCounts[state],

--- a/src/server/views/dashboard/queueList.js
+++ b/src/server/views/dashboard/queueList.js
@@ -3,8 +3,9 @@ const Queues = require('../../bull');
 function handler(req, res) {
   Queues.setConfig(req.app.get('bull config'));
   const queues = Queues.list();
+  const baseURL = req.app.get('baseURL');
 
-  return res.render('dashboard/templates/queueList.hbs', { queues });
+  return res.render('dashboard/templates/queueList.hbs', { queues, baseURL });
 }
 
 module.exports = handler;

--- a/src/server/views/dashboard/templates/jobDetails.hbs
+++ b/src/server/views/dashboard/templates/jobDetails.hbs
@@ -1,10 +1,10 @@
 <h2>Queue <code>{{ queueHost }}/{{ queueName }}</code></h2>
 
-{{> dashboard/jobDetails job queueName=queueName queueHost=queueHost jobState=jobState }}
+{{> dashboard/jobDetails job queueName=queueName baseURL=baseURL queueHost=queueHost jobState=jobState }}
 
 {{#contentFor 'sidebar'}}
-  <li><a href="/dashboard">Queues Overview</a></li>
-  <li><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}">Queue <code>{{ queueHost }}/{{ queueName }}</code></a></li>
-  <li><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ jobState }}">{{capitalize jobState}} Jobs</a></li>
+  <li><a href="{{ baseURL }}/dashboard">Queues Overview</a></li>
+  <li><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}">Queue <code>{{ queueHost }}/{{ queueName }}</code></a></li>
+  <li><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ jobState }}">{{capitalize jobState}} Jobs</a></li>
   <li class="active"><a href="#">Job {{ job.id }}</a></li>
 {{/contentFor}}

--- a/src/server/views/dashboard/templates/jobNotFound.hbs
+++ b/src/server/views/dashboard/templates/jobNotFound.hbs
@@ -3,11 +3,11 @@
 <h3>404</h3>
 <p>Job <code>{{ id }}</code> not found</p>
 <p>
-  <a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}" class="btn btn-primary">Go back to {{ queueHost }}/{{ queueName }}</a>
+  <a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}" class="btn btn-primary">Go back to {{ queueHost }}/{{ queueName }}</a>
 </p>
 
 {{#contentFor 'sidebar'}}
-  <li><a href="/dashboard">Queues Overview</a></li>
-  <li><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}">Queue <code>{{ queueHost }}/{{ queueName }}</code></a></li>
+  <li><a href="{{ baseURL }}/dashboard">Queues Overview</a></li>
+  <li><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}">Queue <code>{{ queueHost }}/{{ queueName }}</code></a></li>
   <li class="active"><a href="#">404</a></li>
 {{/contentFor}}

--- a/src/server/views/dashboard/templates/jobStateNotFound.hbs
+++ b/src/server/views/dashboard/templates/jobStateNotFound.hbs
@@ -3,11 +3,11 @@
 <h3>400</h3>
 <p>Job state <code>{{ state }}</code> does not exist</p>
 <p>
-  <a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}" class="btn btn-primary">Go back to {{ queueHost }}/{{ queueName }}</a>
+  <a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}" class="btn btn-primary">Go back to {{ queueHost }}/{{ queueName }}</a>
 </p>
 
 {{#contentFor 'sidebar'}}
-  <li><a href="/dashboard">Queues Overview</a></li>
-  <li><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}">Queue <code>{{ queueHost }}/{{ queueName }}</code></a></li>
+  <li><a href="{{ baseURL }}/dashboard">Queues Overview</a></li>
+  <li><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}">Queue <code>{{ queueHost }}/{{ queueName }}</code></a></li>
   <li class="active"><a href="#">404</a></li>
 {{/contentFor}}

--- a/src/server/views/dashboard/templates/queueDetails.hbs
+++ b/src/server/views/dashboard/templates/queueDetails.hbs
@@ -7,7 +7,7 @@
       {{#each jobCounts}}
         <li class="list-group-item">
           <span class="badge">{{ this }}</span>
-          <a href="/dashboard/{{ encodeURI ../queueHost }}/{{ encodeURI ../queueName }}/{{ @key }}">
+          <a href="{{ ../baseURL }}/dashboard/{{ encodeURI ../queueHost }}/{{ encodeURI ../queueName }}/{{ @key }}">
             <span class="text-capitalize">{{ @key }}</span>
           </a>
         </li>
@@ -31,6 +31,6 @@
 </div>
 
 {{#contentFor 'sidebar'}}
-  <li><a href="/dashboard">Queues Overview</a></li>
+  <li><a href="{{ baseURL }}/dashboard">Queues Overview</a></li>
   <li class="active"><a href="#">Queue <code>{{ queueHost }}/{{ queueName }}</code></a></li>
 {{/contentFor}}

--- a/src/server/views/dashboard/templates/queueJobsByState.hbs
+++ b/src/server/views/dashboard/templates/queueJobsByState.hbs
@@ -11,7 +11,7 @@
             class="disabled">
               <span>&laquo;</span>
           {{else}}
-            ><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ subtract currentPage 1 }}&amp;pageSize={{ pageSize }}" aria-label="Previous">
+            ><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ subtract currentPage 1 }}&amp;pageSize={{ pageSize }}" aria-label="Previous">
               <span aria-hidden="true">&laquo;</span>
             </a>
           {{/eq}}
@@ -22,7 +22,7 @@
               class="active"
             {{/eq}}>
 
-            <a href="/dashboard/{{ encodeURI ../queueHost }}/{{ encodeURI ../queueName }}/{{ ../state }}?page={{ this }}&amp;pageSize={{ ../pageSize }}">{{ this }}</a>
+            <a href="{{ ../baseURL }}/dashboard/{{ encodeURI ../queueHost }}/{{ encodeURI ../queueName }}/{{ ../state }}?page={{ this }}&amp;pageSize={{ ../pageSize }}">{{ this }}</a>
           </li>
         {{/each}}
         <li
@@ -30,7 +30,7 @@
             class="disabled">
               <span>&raquo;</span>
           {{else}}
-            ><a href="/dashboard/{{ encodeURI ../queueHost }}/{{ encodeURI ../queueName }}/{{ state }}?page={{ add currentPage 1 }}&amp;pageSize={{ pageSize }}" aria-label="Previous">
+            ><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ add currentPage 1 }}&amp;pageSize={{ pageSize }}" aria-label="Previous">
               <span aria-hidden="true">&raquo;</span>
             </a>
           {{/eq}}
@@ -52,12 +52,12 @@
         Page Size <span class="caret"></span>
       </button>
       <ul class="dropdown-menu">
-        <li><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ currentPage }}&amp;pageSize={{ pageSize }}">{{ pageSize }} jobs</a></li>
+        <li><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ currentPage }}&amp;pageSize={{ pageSize }}">{{ pageSize }} jobs</a></li>
         <li role="separator" class="divider"></li>
-        <li><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 5 }}&amp;pageSize=5">5 jobs</a></li>
-        <li><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 20 }}&amp;pageSize=20">20 jobs</a></li>
-        <li><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 100 }}&amp;pageSize=100">100 jobs</a></li>
-        <li><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 1000 }}&amp;pageSize=1000">1000 jobs</a></li>
+        <li><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 5 }}&amp;pageSize=5">5 jobs</a></li>
+        <li><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 20 }}&amp;pageSize=20">20 jobs</a></li>
+        <li><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 100 }}&amp;pageSize=100">100 jobs</a></li>
+        <li><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 1000 }}&amp;pageSize=1000">1000 jobs</a></li>
       </ul>
     </div>
   </div>
@@ -83,7 +83,7 @@
               <h4 class="header-collapse">{{ this.id }}</h4>
             </a>
             <div id="collapse{{this.id}}" class="collapse">
-              {{> dashboard/jobDetails this displayJobInline=true queueName=../queueName queueHost=../queueHost jobState=../state }}
+              {{> dashboard/jobDetails this displayJobInline=true queueName=../queueName baseURL=../baseURL queueHost=../queueHost jobState=../state }}
             </div>
           </li>
         {{/each}}
@@ -97,7 +97,7 @@
 </p>
 
 {{#contentFor 'sidebar'}}
-  <li><a href="/dashboard">Queues Overview</a></li>
-  <li><a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}">Queue <code>{{ queueHost }}/{{ queueName }}</code></a></li>
+  <li><a href="{{ baseURL }}/dashboard">Queues Overview</a></li>
+  <li><a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}">Queue <code>{{ queueHost }}/{{ queueName }}</code></a></li>
   <li class="active"><a href="#">{{capitalize state}} Jobs</a></li>
 {{/contentFor}}

--- a/src/server/views/dashboard/templates/queueList.hbs
+++ b/src/server/views/dashboard/templates/queueList.hbs
@@ -6,7 +6,7 @@
     <ul class="list-group">
       {{#each queues}}
         <li class="list-group-item">
-          <a href="/dashboard/{{ encodeURI this.hostId }}/{{ encodeURI this.name }}">{{ this.hostId }}/{{ this.name }}</a>
+          <a href="{{ ../baseURL }}/dashboard/{{ encodeURI this.hostId }}/{{ encodeURI this.name }}">{{ this.hostId }}/{{ this.name }}</a>
         </li>
       {{/each}}
     </ul>

--- a/src/server/views/dashboard/templates/queueNotFound.hbs
+++ b/src/server/views/dashboard/templates/queueNotFound.hbs
@@ -3,10 +3,10 @@
 <h3>404</h3>
 <p>Queue <code>{{ queueHost }}/{{ queueName }}</code> not found</p>
 <p>
-  <a href="/dashboard" class="btn btn-primary">Go back to Overview</a>
+  <a href="{{ baseURL }}/dashboard" class="btn btn-primary">Go back to Overview</a>
 </p>
 
 {{#contentFor 'sidebar'}}
-  <li><a href="/dashboard">Queues Overview</a></li>
+  <li><a href="{{ baseURL }}/dashboard">Queues Overview</a></li>
   <li class="active"><a href="#">404</a></li>
 {{/contentFor}}

--- a/src/server/views/layout.hbs
+++ b/src/server/views/layout.hbs
@@ -8,10 +8,10 @@
 
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/bootstrap/3.3.7/css/bootstrap.min.css">
-    <link rel="stylesheet" href="/dashboard.css">
+    <link rel="stylesheet" href="{{ baseURL }}/dashboard.css">
   </head>
 
-  <body>
+  <body data-base-url="{{ baseURL }}">
     <nav class="navbar navbar-inverse navbar-fixed-top">
       <div class="container-fluid">
         <div class="navbar-header">
@@ -21,11 +21,11 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="/dashboard">Arena</a>
+          <a class="navbar-brand" href="{{ baseURL }}/dashboard">Arena</a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="/dashboard">Dashboard</a></li>
+            <li><a href="{{ baseURL }}/dashboard">Dashboard</a></li>
           </ul>
         </div>
       </div>
@@ -46,6 +46,6 @@
       </div>
     </div>
     <script type="text/javascript" src="//cdn.jsdelivr.net/g/jquery@3.2.1,bootstrap@3.3.7"></script>
-    <script type="text/javascript" src="/dashboard.js"></script>
+    <script type="text/javascript" src="{{ baseURL }}/dashboard.js"></script>
   </body>
 </html>

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -15,7 +15,7 @@
 
 <div class="row">
   <div class="col-sm-3">
-    <h5>State</h5>
+    <h5>State{{ baseURL }}</h5>
     {{capitalize jobState}}
   </div>
 
@@ -31,8 +31,8 @@
 
   <div class="col-sm-3">
     <h5>Permalinks</h5>
-    <a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ this.id }}" class="btn btn-info">Job {{ this.id }}</a>
-    <a href="/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ this.id }}?json=true" class="btn btn-info">JSON</a>
+    <a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ this.id }}" class="btn btn-info">Job {{ this.id }}</a>
+    <a href="{{ baseURL }}/dashboard/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ this.id }}?json=true" class="btn btn-info">JSON</a>
   </div>
 </div>
 


### PR DESCRIPTION
This is my solution to solve #29, which I just opened. You guys may want to implement it differently though, but for my use case this is working great.

With these changes you can initialize arena like this:
```js
const options = { 
    disableListen: true, 
    baseURL: '/arena'
}
const arenaRouter = arena({ queues: getQueueConfig() }, options)
router.use('/arena', arenaRouter)
```

The `baseURL` provided gets set as an option on express, and then is passed to each of the hbs templates to be prepended to each URL. It's also set as a data attribute on the body so that it can be accessed by the client js to prepend it when making api calls.

I've added backwards compatibility with the way `disableListen` is being handled currently.

I also noticed #28 while I was in there and fixed it.