### PR TITLE
Resolve #45 - progress bar display

### DIFF
--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -45,6 +45,7 @@
   </div>
 </div>
 
+{{#unless this.queue.IS_BEE}}
 <h5>Progress</h5>
 <div class="progress">
   <div class="progress-bar
@@ -52,13 +53,14 @@
               progress-bar-danger
               {{/eq}}"
        role="progressbar"
-       aria-valuenow="{{ this.progress }}"
+       aria-valuenow="{{ this._progress }}"
        aria-valuemin="0"
        aria-valuemax="100"
-       style="width: {{ this.progress }}%; min-width: 2em;">
-    {{ this.progress }}%
+       style="width: {{ this._progress }}%; min-width: 2em;">
+    {{ this._progress }}%
   </div>
 </div>
+{{/unless}}
 
 {{#if this.returnvalue}}
 <pre>{{ this.returnvalue }}</pre>


### PR DESCRIPTION
Fix logic for displaying progress bar section of job detail page.
Don't display the progress bar section at all if the Queue type is Bee. If the queue is not Bee (ie, it's Bull) then display the progress display, but use it as `_progress` instead of `progress`