### PR TITLE
Support bulk actions on jobs with encoded characters

### DIFF
--- a/src/server/views/api/bulkAction.js
+++ b/src/server/views/api/bulkAction.js
@@ -21,7 +21,7 @@ function bulkAction(action) {
 
     try {
       if (!_.isEmpty(jobs)) {
-        const jobsPromises = jobs.map((id) => queue.getJob(id));
+        const jobsPromises = jobs.map((id) => queue.getJob(decodeURIComponent(id)));
         const fetchedJobs = await Promise.all(jobsPromises);
 
         const actionPromises = fetchedJobs.map(job => job[action]());


### PR DESCRIPTION
The UI sends an array of url encoded Job Ids when doing things like Bulk Remove Jobs. 

This change allows the server to decode these ids to resolve to the correct job id.