### PR TITLE
Allow Arena to connect to queues using a Redis URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Configure your queues in the "queues" key of [`index.json`](src/server/config/in
 The `name`, `port`, `host`, and `hostId` fields are required. `hostId` can be given any name, so it is recommended to give it a helpful name for reference. 
 Optionally, you can also pass in `db` and `password` to configure redis credentials, or `prefix` to specify the customized prefix of the queue.
 
+You can also provide a `url` field instead of `host`, `port` `db` and `password`.
+
 To specify a custom file location, see "Running Arena as a node module".
 
 *Note that if you happen to use Amazon Web Services' Elasticache as your Redis host, check out http://mixmax.com/blog/bull-queue-aws-autodiscovery*

--- a/src/server/queue/index.js
+++ b/src/server/queue/index.js
@@ -29,13 +29,13 @@ class Queues {
       return this._queues[queueHost][queueName];
     }
 
-    const { type, name, port, host, db, password, prefix } = queueConfig;
+    const { type, name, port, host, db, password, prefix, url } = queueConfig;
 
     const isBee = type === 'bee';
 
     const options = {
       prefix,
-      redis: { port, host, db, password }
+      redis: url || { port, host, db, password }
     };
 
     let queue;


### PR DESCRIPTION
Both Bull and Bee allow `redis` in their config to be a URL or an object.
We're using Redis-URL to connect to redis so this patch adds an optional `url` field.

If given, it will be used to construct Redis configuration instead of `host`, `port`, `db` and `password`.