### PR TITLE
fix hostId/host misuse

### DIFF
--- a/src/server/queue/index.js
+++ b/src/server/queue/index.js
@@ -21,7 +21,7 @@ class Queues {
   async get(queueName, queueHost) {
     const queueConfig = _.find(this._config.queues, {
       name: queueName,
-      hostId: queueHost
+      host: queueHost
     });
     if (!queueConfig) return null;
 


### PR DESCRIPTION
> The name, port, host, and hostId fields are required. hostId can be given any name, so it is recommended to give it a helpful name for reference.

As I understand hostId is alias for host, so it should be used only in templates...

p.s. Why host/port have no default value? 127.0.0.1:6379 would fit for newbies (like me)