### PR TITLE
json Handlebars helper allows unsafe HTML

### DIFF
--- a/src/server/views/helpers/handlebars.js
+++ b/src/server/views/helpers/handlebars.js
@@ -1,8 +1,17 @@
-const _ = require('lodash');
-const Handlebars = require('handlebars');
+const _ = require("lodash");
+const Handlebars = require("handlebars");
 
-const replacer = (key, value) =>
-    _.isString(value) ? Handlebars.Utils.escapeExpression(value) : value;
+const replacer = (key, value) => {
+  if (_.isObject(value)) {
+    return _.transform(value, (result, v, k) => {
+      result[Handlebars.Utils.escapeExpression(k)] = v;
+    });
+  } else if (_.isString(value)) {
+    return Handlebars.Utils.escapeExpression(value);
+  } else {
+    return value;
+  }
+};
 
 const helpers = {
   json(obj, pretty = false) {
@@ -20,18 +29,18 @@ const helpers = {
 
   block(name) {
     var blocks = this._blocks;
-        content = blocks && blocks[name];
-    return content ? content.join('\n') : null;
+    content = blocks && blocks[name];
+    return content ? content.join("\n") : null;
   },
 
   contentFor: function(name, options) {
     var blocks = this._blocks || (this._blocks = {});
-        block = blocks[name] || (blocks[name] = []);
+    block = blocks[name] || (blocks[name] = []);
     block.push(options.fn(this));
   },
 
-  encodeIdAttr: function (id) {
-      return id.replace(/:| /g, "");
+  encodeIdAttr: function(id) {
+    return id.replace(/:| /g, "");
   }
 };
 

--- a/src/server/views/helpers/handlebars.js
+++ b/src/server/views/helpers/handlebars.js
@@ -1,15 +1,16 @@
 const _ = require('lodash');
-const Handlerbars = require('handlebars');
+const Handlebars = require('handlebars');
+
+const replacer = (key, value) =>
+    _.isString(value) ? Handlebars.Utils.escapeExpression(value) : value;
 
 const helpers = {
   json(obj, pretty = false) {
-    var d;
+    const args = [obj, replacer];
     if (pretty) {
-      d = JSON.stringify(obj, null, 2);
-    } else {
-      d = JSON.stringify(obj);
+      args.push(2);
     }
-    return new Handlerbars.SafeString(d);
+    return new Handlebars.SafeString(JSON.stringify(...args));
   },
 
   adjustedPage(currentPage, pageSize, newPageSize) {

--- a/src/server/views/helpers/handlebars.js
+++ b/src/server/views/helpers/handlebars.js
@@ -28,18 +28,18 @@ const helpers = {
   },
 
   block(name) {
-    var blocks = this._blocks;
-    content = blocks && blocks[name];
+    const blocks = this._blocks;
+    const content = blocks && blocks[name];
     return content ? content.join("\n") : null;
   },
 
-  contentFor: function(name, options) {
-    var blocks = this._blocks || (this._blocks = {});
-    block = blocks[name] || (blocks[name] = []);
+  contentFor(name, options) {
+    const blocks = this._blocks || (this._blocks = {});
+    const block = blocks[name] || (blocks[name] = []);
     block.push(options.fn(this));
   },
 
-  encodeIdAttr: function(id) {
+  encodeIdAttr(id) {
     return id.replace(/:| /g, "");
   }
 };

--- a/src/server/views/helpers/handlebars.js
+++ b/src/server/views/helpers/handlebars.js
@@ -1,5 +1,5 @@
-const _ = require("lodash");
-const Handlebars = require("handlebars");
+const _ = require('lodash');
+const Handlebars = require('handlebars');
 
 const replacer = (key, value) => {
   if (_.isObject(value)) {
@@ -30,7 +30,7 @@ const helpers = {
   block(name) {
     const blocks = this._blocks;
     const content = blocks && blocks[name];
-    return content ? content.join("\n") : null;
+    return content ? content.join('\n') : null;
   },
 
   contentFor(name, options) {
@@ -40,7 +40,7 @@ const helpers = {
   },
 
   encodeIdAttr(id) {
-    return id.replace(/:| /g, "");
+    return id.replace(/:| /g, '');
   }
 };
 


### PR DESCRIPTION
I noticed this vulnerability when I added a job to Bull that had job data that included some HTML. Since the `json` Handlebars helper assumes that its input is safe, any HTML that is rendered onto the job details page will be considered valid, including `<script>` tags.

You can repro this by creating a job in Bull (and maybe in Bee?) with data along the lines of
```json
{
  "something": "<script>alert('Hello there!')</script>"
}
```

and then opening up the `queueJobsByState` page that includes the job with unsafe HTML. You'll see an alert.

bug is in this helper function: https://github.com/bee-queue/arena/blob/be866d368b44f95dbe4424ba71d6b5ec7d7843e9/src/server/views/helpers/handlebars.js#L5

I've attached a fix in which all string values are escaped when the object is stringified.