### PR TITLE
Fix Bull queue construction so the url option is respected.

### DIFF
--- a/src/server/queue/index.js
+++ b/src/server/queue/index.js
@@ -38,26 +38,24 @@ class Queues {
 
     const isBee = type === 'bee';
 
+    const options = {
+      redis: redis || url || redisHost
+    };
+    if (prefix) options.prefix = prefix;
+
     let queue;
     if (isBee) {
-      const options = {
-        redis: redis || url || redisHost,
+      _.extend(options, {
         isWorker: false,
         getEvents: false,
         sendEvents: false,
         storeJobs: false
-      };
-      if (prefix) options.prefix = prefix;
+      });
 
       queue = new Bee(name, options);
       queue.IS_BEE = true;
     } else {
-      const options = {
-        redis: redis || redisHost
-      };
-      if (prefix) options.prefix = prefix;
-
-      queue = new Bull(name, options || url);
+      queue = new Bull(name, options);
     }
 
     this._queues[queueHost] = this._queues[queueHost] || {};


### PR DESCRIPTION
https://github.com/bee-queue/arena/pull/85/files#diff-623167d1c54ecd199ee8a745a96c568fL60

As you can see here, there was no way that `url` could ever be used as `options` was always guaranteed to exist. Since the Bee and Bull branches are very similar, I hoisted the `options` declaration out of the if/else statement.