### PR TITLE
Use node:alpine image for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.1.2
+FROM node:alpine
 
 EXPOSE 4567
 


### PR DESCRIPTION
Currently docker image is building over `node:8.1.2`, it uses debian jessie and it's too big. Arena only needs a node environment so there seems to be no reason not to use `node:alpine`