### PR TITLE
Ensure job progress is displayed (compatibility with latest version of bull)

### DIFF
--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -54,11 +54,11 @@
               progress-bar-danger
               {{/eq}}"
        role="progressbar"
-       aria-valuenow="{{ this._progress }}"
+       aria-valuenow="{{ this.progress }}"
        aria-valuemin="0"
        aria-valuemax="100"
-       style="width: {{ this._progress }}%; min-width: 2em;">
-    {{ this._progress }}%
+       style="width: {{ this.progress }}%; min-width: 2em;">
+    {{ this.progress }}%
   </div>
 </div>
 {{/unless}}


### PR DESCRIPTION
As of bull 3.4.2 (and probably earlier), the progress of a job is provided in `progress`, not `_progress`. This commit updates the view template to match.

This fixes a problem where the progress of any bull job would always appear in arena as "0%". Now the correct progress is shown.

See: https://github.com/OptimalBits/bull/blob/v3.4.2/lib/job.js#L129