### PR TITLE
Allow Yarn again

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "inspect": "nodemon --inspect --trace-warnings index.js"
   },
   "engines": {
-    "node": ">=7.6.0",
-    "yarn": "YARN NO LONGER USED - use npm instead."
+    "node": ">=7.6.0"
   },
   "repository": "https://github.com/bee-queue/arena.git",
   "version": "2.4.4"


### PR DESCRIPTION
We shouldn’t use it to develop on the module, but users should be able to use
it to install the module just fine.

Fixes https://github.com/bee-queue/arena/issues/99.