### PR TITLE
Fix bug when clicking through to state page

### DIFF
--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -11,7 +11,7 @@ const { BEE_STATES, BULL_STATES } = require('../helpers/queueHelpers');
  */
 function isValidState(state, isBee) {
   const validStates = isBee ? BEE_STATES : BULL_STATES;
-  return _.includes(jobTypes, state);
+  return _.includes(validStates, state);
 }
 
 async function handler(req, res) {


### PR DESCRIPTION
Clicking through to the state page was broken with this code. `jobTypes` does not exist in function.

Fixes #110 