### PR TITLE
Populate redis with redisHost values

### DIFF
--- a/src/server/queue/index.js
+++ b/src/server/queue/index.js
@@ -45,7 +45,8 @@ class Queues {
     if (password) redisHost.password = password;
     if (port) redisHost.port = port;
     if (db) redisHost.db = db;
-
+    if (!!redis) redis = Object.assign(redisHost, redis);
+    
     const isBee = type === 'bee';
 
     const options = {


### PR DESCRIPTION
If for some reason you separate some values in the queue configuration, such as having on one side the sentinels and on the other the database index or the password, in this way they come together and cease to be exclusive.

For example, this: 
```
{
      "name": "example",
      "redis": {
        "name": "myexample",
        "sentinels": [ { "host": "redis-1", "port": 26379 }, { "host": "redis-2", "port": 26379 }, { "host": "redis-3", "port": 26379 } ]
      },
      "db": "2",
      "password": "thisisapassword",
      "hostId": "2:global",
      "prefix": "{example}"
    }
```
becomes ... :
```
options = {
    redis: {
        name: "myexample",
        db: 2,
        password: "thisisapassword",
        sentinels: [ { "host": "redis-1", "port": 26379 }, { "host": "redis-2", "port": 26379 }, { "host": "redis-3", "port": 26379 } ]
    }
}
```