### PR TITLE
fix: base path with nested routes which may have wildcards

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,10 @@ function run(config, listenOpts = {}) {
   if (config) Queues.setConfig(config);
   Queues.useCdn = typeof listenOpts.useCdn !== 'undefined' ? listenOpts.useCdn : true;
 
-  app.locals.basePath = listenOpts.basePath || app.locals.basePath;
+  app.locals.appBasePath = listenOpts.basePath || app.locals.appBasePath;
 
-  app.use(app.locals.basePath, express.static(path.join(__dirname, 'public')));
-  app.use(app.locals.basePath, routes);
+  app.use(app.locals.appBasePath, express.static(path.join(__dirname, 'public')));
+  app.use(app.locals.appBasePath, routes);
 
   const port = listenOpts.port || 4567;
   const host= listenOpts.host || '0.0.0.0'; // Default: listen to all network interfaces.

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -22,7 +22,7 @@ module.exports = function() {
   const queues = new Queues(defaultConfig);
   require('./views/helpers/handlebars')(handlebars, { queues });
   app.locals.Queues = queues;
-  app.locals.basePath = '';
+  app.locals.appBasePath = '';
 
   app.set('views', `${__dirname}/views`);
   app.set('view engine', 'hbs');

--- a/src/server/views/dashboard/jobDetails.js
+++ b/src/server/views/dashboard/jobDetails.js
@@ -4,13 +4,14 @@ const util = require('util');
 async function handler(req, res) {
   const { queueName, queueHost, id } = req.params;
   const { json } = req.query;
+  const basePath = req.baseUrl;
 
   const {Queues} = req.app.locals;
   const queue = await Queues.get(queueName, queueHost);
-  if (!queue) return res.status(404).render('dashboard/templates/queueNotFound', {queueName, queueHost});
+  if (!queue) return res.status(404).render('dashboard/templates/queueNotFound', {basePath, queueName, queueHost});
 
   const job = await queue.getJob(id);
-  if (!job) return res.status(404).render('dashboard/templates/jobNotFound', {id, queueName, queueHost});
+  if (!job) return res.status(404).render('dashboard/templates/jobNotFound', {basePath, id, queueName, queueHost});
 
   if (json === 'true') {
     delete job.queue; // avoid circular references parsing error
@@ -25,6 +26,7 @@ async function handler(req, res) {
   }
 
   return res.render('dashboard/templates/jobDetails', {
+    basePath,
     queueName,
     queueHost,
     jobState,

--- a/src/server/views/dashboard/queueDetails.js
+++ b/src/server/views/dashboard/queueDetails.js
@@ -5,7 +5,8 @@ async function handler(req, res) {
   const {queueName, queueHost} = req.params;
   const {Queues} = req.app.locals;
   const queue = await Queues.get(queueName, queueHost);
-  if (!queue) return res.status(404).render('dashboard/templates/queueNotFound', {queueName, queueHost});
+  const basePath = req.baseUrl;
+  if (!queue) return res.status(404).render('dashboard/templates/queueNotFound', {basePath, queueName, queueHost});
 
   let jobCounts;
   if (queue.IS_BEE) {
@@ -17,6 +18,7 @@ async function handler(req, res) {
   const stats = await QueueHelpers.getStats(queue);
 
   return res.render('dashboard/templates/queueDetails', {
+    basePath,
     queueName,
     queueHost,
     jobCounts,

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -60,7 +60,8 @@ async function _html(req, res) {
   const { queueName, queueHost, state } = req.params;
   const {Queues} = req.app.locals;
   const queue = await Queues.get(queueName, queueHost);
-  if (!queue) return res.status(404).render('dashboard/templates/queueNotFound', {queueName, queueHost});
+  const basePath = req.baseUrl;
+  if (!queue) return res.status(404).render('dashboard/templates/queueNotFound', {basePath, queueName, queueHost});
 
   if (!isValidState(state, queue.IS_BEE)) return res.status(400).json({ message: `Invalid state requested: ${state}` });
 
@@ -105,6 +106,7 @@ async function _html(req, res) {
   pages = pages.filter((page) => page <= _.ceil(jobCounts[state] / pageSize));
 
   return res.render('dashboard/templates/queueJobsByState', {
+    basePath,
     queueName,
     queueHost,
     state,

--- a/src/server/views/dashboard/queueList.js
+++ b/src/server/views/dashboard/queueList.js
@@ -1,8 +1,9 @@
 function handler(req, res) {
   const {Queues} = req.app.locals;
   const queues = Queues.list();
+  const basePath = req.baseUrl;
 
-  return res.render('dashboard/templates/queueList', { queues });
+  return res.render('dashboard/templates/queueList', { basePath, queues });
 }
 
 module.exports = handler;


### PR DESCRIPTION
Fixes #105 but also allows for the route to have a wildcard

```
const arena = Arena({
  queues: [
    {
      // ...
    }
  ],
}, {
  basePath: '/jobs',
  disableListen: true,
});

// [...]

app.use('/user/:id', arena);
```

Will result in a path /user/:id/jobs which can then be matched to an actual url like user/1/jobs