### PR TITLE
Support Redis-over-TLS

### DIFF
--- a/src/server/queue/index.js
+++ b/src/server/queue/index.js
@@ -39,12 +39,13 @@ class Queues {
       return this._queues[queueHost][queueName];
     }
 
-    const { type, name, port, host, db, password, prefix, url, redis } = queueConfig;
+    const { type, name, port, host, db, password, prefix, url, redis, tls } = queueConfig;
 
     const redisHost = { host };
     if (password) redisHost.password = password;
     if (port) redisHost.port = port;
     if (db) redisHost.db = db;
+    if (tls) redisHost.tls = tls;
 
     const isBee = type === 'bee';
 


### PR DESCRIPTION
Currently Arena does not pass forward any TLS opts it receives as part of the Redis config. If a TLS opt is supplied, it should be passed to the queue Redis configuration so that Arena can read from TLS-enabled Redis instances.