### PR TITLE
Allow arena to work as a node module alongside auth middleware.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,10 @@ function run(config, listenOpts = {}) {
   Queues.useCdn = typeof listenOpts.useCdn !== 'undefined' ? listenOpts.useCdn : true;
 
   app.locals.appBasePath = listenOpts.basePath || app.locals.appBasePath;
-
-  app.use(app.locals.appBasePath, express.static(path.join(__dirname, 'public')));
-  app.use(app.locals.appBasePath, routes);
+  app.locals.mountPath = listenOpts.mountPath || app.locals.basePath;
+  
+  app.use(app.locals.mountPath, express.static(path.join(__dirname, 'public')));
+  app.use(app.locals.mountPath, routes);
 
   const port = listenOpts.port || 4567;
   const host= listenOpts.host || '0.0.0.0'; // Default: listen to all network interfaces.


### PR DESCRIPTION
I have been unable to find a way to add arena to an existing express app while also implementing authentication.  The basePath parameter conflicts with any path other than "/" provided to express' use method.  Allowing users to provide a new parameter called "mountPath" can alleviate this issue and allow configs like the following to work:

```
const arena = Arena({
    queues
}, {
    basePath: '/admin/',
    mountPath: '/',
    disableListen: true
})

app.use('/admin', basicAuth('foo', 'bar'), arena)
```

where basicAuth = https://github.com/expressjs/basic-auth-connect
