### PR TITLE
Fixes issue preventing expand/collapse functionality from working when job ids contain special characters

### DIFF
--- a/src/server/views/dashboard/templates/queueJobsByState.hbs
+++ b/src/server/views/dashboard/templates/queueJobsByState.hbs
@@ -93,7 +93,7 @@
               <input class="js-bulk-job" name="jobChecked" type="checkbox" />
             </div>
 
-            <a role="button" data-toggle="collapse" href="#collapse{{encodeIdAttr this.id}}">
+            <a role="button" data-toggle="collapse" href="#collapse{{hashIdAttr this.id}}">
               <h4 class="header-collapse">
                 <span class="label label-default">{{ this.id }}</span>
                 {{#if this.data.name}}
@@ -103,7 +103,7 @@
                 {{/if}}
               </h4>
             </a>
-            <div id="collapse{{encodeIdAttr this.id}}" class="collapse">
+            <div id="collapse{{hashIdAttr this.id}}" class="collapse">
               {{~> dashboard/jobDetails this basePath=../basePath displayJobInline=true queueName=../queueName queueHost=../queueHost jobState=../state }}
             </div>
           </li>

--- a/src/server/views/helpers/handlebars.js
+++ b/src/server/views/helpers/handlebars.js
@@ -41,7 +41,7 @@ const helpers = {
   },
 
   hashIdAttr(id) {
-    return crypto.createHash('md5').update(id).digest('hex');
+    return crypto.createHash('sha256').update(id).digest('hex');
   }
 };
 

--- a/src/server/views/helpers/handlebars.js
+++ b/src/server/views/helpers/handlebars.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto')
 const _ = require('lodash');
 const Handlebars = require('handlebars');
 
@@ -39,8 +40,8 @@ const helpers = {
     block.push(options.fn(this));
   },
 
-  encodeIdAttr(id) {
-    return id.replace(/:| /g, '');
+  hashIdAttr(id) {
+    return crypto.createHash('md5').update(id).digest('hex');
   }
 };
 


### PR DESCRIPTION
Fixes #116 

I did try escaping these characters first but it did not seem to help at all, so just went with a hash since the result is not currently being used for anything other than generating a unique attribute value.