### PR TITLE
Support passing createClient to Bull

### DIFF
--- a/src/server/queue/index.js
+++ b/src/server/queue/index.js
@@ -66,6 +66,7 @@ class Queues {
       queue = new Bee(name, options);
       queue.IS_BEE = true;
     } else {
+      if (queueConfig.createClient) options.createClient = queueConfig.createClient;
       queue = new Bull(name, options);
     }
 


### PR DESCRIPTION
Hey there, thanks for the handy GUI!

This change makes it possible to control the creation of Redis clients when using Bull, instead of having a new connection created for each and every queue. It uses the pattern documented by Bull [here](https://github.com/OptimalBits/bull/blob/master/PATTERNS.md#reusing-redis-connections) which is helpful if you have many queues and not so many connections available.

There's already a similar feature for Bee-Queue, where you can pass a node_redis instance in the `redis` option, so I've only added this option for Bull.