### PR TITLE
support "paused" as a state for bull queues. closes #132

### DIFF
--- a/src/server/views/dashboard/index.js
+++ b/src/server/views/dashboard/index.js
@@ -7,7 +7,7 @@ const jobDetails = require('./jobDetails');
 
 router.get('/', queueList);
 router.get('/:queueHost/:queueName', queueDetails);
-router.get('/:queueHost/:queueName/:state(waiting|active|completed|succeeded|failed|delayed)\.:ext?', queueJobsByState);
+router.get('/:queueHost/:queueName/:state(waiting|active|completed|succeeded|failed|delayed|paused)\.:ext?', queueJobsByState);
 router.get('/:queueHost/:queueName/:id', jobDetails);
 
 module.exports = router;

--- a/src/server/views/helpers/queueHelpers.js
+++ b/src/server/views/helpers/queueHelpers.js
@@ -24,7 +24,7 @@ const Helpers = {
   /**
    * Valid states for a job in bull queue
    */
-  BULL_STATES: ['waiting', 'active', 'completed', 'failed', 'delayed']
+  BULL_STATES: ['waiting', 'active', 'completed', 'failed', 'delayed', 'paused']
 };
 
 module.exports = Helpers;


### PR DESCRIPTION
Previously the `bull-arena` package did not support paused as a valid bull queue state, despite the UI showing it as one. This ended up causing server crashes due when you navigate to the `paused` queue state due to trying to read the key from redis as an individual job, rather than a list (HGETALL vs LRANGE).

<img width="457" alt="screen shot 2018-11-13 at 1 30 01 pm" src="https://user-images.githubusercontent.com/710752/48437944-613f4c80-e748-11e8-9ea7-8bb5d447b606.png">

This change should map `/:queueName/paused` to the `queueJobsByState` instead of the `jobDetails` handler.