### PR TITLE
Bump handlerbars-helper to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "express": "^4.15.2",
     "express-handlebars": "^3.0.0",
     "handlebars": "^4.0.10",
-    "handlebars-helpers": "^0.8.2",
+    "handlebars-helpers": "^0.10.0",
     "lodash": "^4.17.4",
     "nodemon": "^1.18.7"
   },


### PR DESCRIPTION
https://nodesecurity.io/advisories/745 just came out, which affects versions of underscore.string prior to 3.3.5. bull-arena includes this via handlebars-helpers, which has had a more recent version out for a while now that uses a patched dependency.