### PR TITLE
Fixing navbar toggle in the main layout

### DIFF
--- a/src/server/views/layout.hbs
+++ b/src/server/views/layout.hbs
@@ -43,7 +43,7 @@
 
     <div class="container-fluid">
       <div class="row">
-        <div class="col-sm-3 col-md-2 sidebar">
+        <div id="navbar" class="col-sm-3 col-md-2 sidebar">
           <h4>Queue Navigation Tree</h4>
           <ul class="nav nav-sidebar">
             {{{block "sidebar"}}}


### PR DESCRIPTION
On small screens (e.g. mobile devices) the `navbar` at the top of the screen does **not** function due to the missing reference to the `div`.