### PR TITLE
Fix "add job" vendor/API path when basePath is set

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -135,13 +135,13 @@ $(document).ready(() => {
     const data = localStorage.getItem('arena:savedJobData') || '{ id: \'\' }';
     window.jsonEditor.set(JSON.parse(data));
   });
-  
+
   $('.js-add-job').on('click', function() {
     const data = window.jsonEditor.get();
     localStorage.setItem('arena:savedJobData', JSON.stringify(data));
     const { queueHost, queueName } = window.arenaInitialPayload;
     $.ajax({
-      url: `/api/queue/${queueHost}/${queueName}/job`,
+      url: `${basePath}/api/queue/${queueHost}/${queueName}/job`,
       type: 'POST',
       data: JSON.stringify(data),
       contentType: 'application/json'

--- a/src/server/views/layout.hbs
+++ b/src/server/views/layout.hbs
@@ -23,8 +23,8 @@
     <link rel="stylesheet" href="{{ basePath }}/dashboard.css">
     <script>hljs.initHighlightingOnLoad();</script>
 
-    <link rel="stylesheet" href="{{ vendorPath }}/jsoneditor.min.css">
-    <link rel="stylesheet" href="{{ vendorPath }}/tablesort.css">
+    <link rel="stylesheet" href="{{ basePath }}{{ vendorPath }}/jsoneditor.min.css">
+    <link rel="stylesheet" href="{{ basePath }}{{ vendorPath }}/tablesort.css">
   </head>
 
   <body>
@@ -66,8 +66,8 @@
     <script type="text/javascript" src="{{ basePath }}/bootstrap.min.js"></script>
     {{/if}}
 
-    <script type="text/javascript" src="{{ vendorPath }}/jsoneditor.min.js"></script>
-    <script type="text/javascript" src="{{ vendorPath }}/tablesort.min.js"></script>
+    <script type="text/javascript" src="{{ basePath }}{{ vendorPath }}/jsoneditor.min.js"></script>
+    <script type="text/javascript" src="{{ basePath }}{{ vendorPath }}/tablesort.min.js"></script>
 
     <script type="text/javascript" src="{{ basePath }}/dashboard.js"></script>
     <script>


### PR DESCRIPTION
The shiny new "add job" ✨codes need to follow the basePath prefix convention used elsewhere in order for everything to work correctly when a basePath is set – currently the JS/CSS assets won't be loaded, and the API request will 404!