### PR TITLE
fix when baseUrl and routeUrl is not the same

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,14 @@ function run(config, listenOpts = {}) {
   if (config) Queues.setConfig(config);
   Queues.useCdn = typeof listenOpts.useCdn !== 'undefined' ? listenOpts.useCdn : true;
 
-  app.locals.appBasePath = listenOpts.basePath || app.locals.appBasePath;
-
-  app.use('/', express.static(path.join(__dirname, 'public')));
-  app.use('/', routes);
+  if (listenOpts.disableListen) { 
+    app.locals.appBasePath = listenOpts.basePath || app.locals.appBasePath;
+    app.use('/', express.static(path.join(__dirname, 'public')));
+    app.use('/', routes);
+  } else {
+    app.use(listenOpts.basePath || app.locals.appBasePath, express.static(path.join(__dirname, 'public')));
+    app.use(listenOpts.basePath || app.locals.appBasePath, routes);
+  }
 
   const port = listenOpts.port || 4567;
   const host= listenOpts.host || '0.0.0.0'; // Default: listen to all network interfaces.

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ function run(config, listenOpts = {}) {
 
   app.locals.appBasePath = listenOpts.basePath || app.locals.appBasePath;
 
-  app.use(app.locals.appBasePath, express.static(path.join(__dirname, 'public')));
-  app.use(app.locals.appBasePath, routes);
+  app.use('/', express.static(path.join(__dirname, 'public')));
+  app.use('/', routes);
 
   const port = listenOpts.port || 4567;
   const host= listenOpts.host || '0.0.0.0'; // Default: listen to all network interfaces.

--- a/src/server/views/dashboard/jobDetails.js
+++ b/src/server/views/dashboard/jobDetails.js
@@ -4,7 +4,7 @@ const util = require('util');
 async function handler(req, res) {
   const { queueName, queueHost, id } = req.params;
   const { json } = req.query;
-  const basePath = req.baseUrl;
+  const basePath = req.app.locals.appBasePath + req.baseUrl;
 
   const {Queues} = req.app.locals;
   const queue = await Queues.get(queueName, queueHost);

--- a/src/server/views/dashboard/queueDetails.js
+++ b/src/server/views/dashboard/queueDetails.js
@@ -5,7 +5,7 @@ async function handler(req, res) {
   const {queueName, queueHost} = req.params;
   const {Queues} = req.app.locals;
   const queue = await Queues.get(queueName, queueHost);
-  const basePath = req.baseUrl;
+  const basePath = req.app.locals.appBasePath + req.baseUrl;
   if (!queue) return res.status(404).render('dashboard/templates/queueNotFound', {basePath, queueName, queueHost});
 
   let jobCounts;

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -60,7 +60,7 @@ async function _html(req, res) {
   const { queueName, queueHost, state } = req.params;
   const {Queues} = req.app.locals;
   const queue = await Queues.get(queueName, queueHost);
-  const basePath = req.baseUrl;
+  const basePath = req.app.locals.appBasePath + req.baseUrl;
   if (!queue) return res.status(404).render('dashboard/templates/queueNotFound', {basePath, queueName, queueHost});
 
   if (!isValidState(state, queue.IS_BEE)) return res.status(400).json({ message: `Invalid state requested: ${state}` });

--- a/src/server/views/dashboard/queueList.js
+++ b/src/server/views/dashboard/queueList.js
@@ -1,7 +1,7 @@
 function handler(req, res) {
   const {Queues} = req.app.locals;
   const queues = Queues.list();
-  const basePath = req.baseUrl;
+  const basePath = req.app.locals.appBasePath + req.baseUrl;
 
   return res.render('dashboard/templates/queueList', { basePath, queues });
 }


### PR DESCRIPTION
Fix problems that cannot be accessed when ``and`` are not the same

| scenario | `listenOpts.basePath` | `app.locals.appBasePath` |
| --- | --- | --- |
| standalone | use to mount route | keep empty |
| middleware | external base path | the same |

usage example
```ts
const url = new URL(config.get('server.url'));
app.use(
  '/arena',
  basicAuth({ users: { user: 'pass' }, challenge: true }),
  Arena(
    {
      queues: [
        {
          name: 'default',
          hostId: '默认',
          redis: config.get('redis[2]'),
        },
      ],
    },
    {
      disableListen: true,
      basePath: url.pathname,
    },
  ),
);
```

fix #162 