### PR TITLE
Add 'next run' field to delayed job info

### DIFF
--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -105,6 +105,14 @@ async function _html(req, res) {
   }
   pages = pages.filter((page) => page <= _.ceil(jobCounts[state] / pageSize));
 
+  if (state === 'delayed') {
+    jobs.forEach(job => {
+      if (!isNaN(job.delay)) {
+        job.nextRun = (job.timestamp || job.options.timestamp) + job.delay;
+      }
+    });
+  }
+
   return res.render('dashboard/templates/queueJobsByState', {
     basePath,
     queueName,

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -106,7 +106,7 @@ async function _html(req, res) {
   pages = pages.filter((page) => page <= _.ceil(jobCounts[state] / pageSize));
 
   if (state === 'delayed') {
-    jobs.forEach(job => {
+    jobs.forEach((job) => {
       if (!isNaN(job.delay)) {
         job.nextRun = (job.timestamp || job.options.timestamp) + job.delay;
       }

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -39,10 +39,10 @@
   </div>
 
   {{#if this.nextRun}}
-  <div class="col-sm-3">
-    <h5>Next run</h5>
-    {{moment this.nextRun "llll"}}
-  </div>
+    <div class="col-sm-3">
+      <h5>Next run</h5>
+      {{moment this.nextRun "llll"}}
+    </div>
   {{/if}}
 </div>
 <div class="row">

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -37,6 +37,13 @@
       {{length this.options.stacktraces}}
     {{/if}}
   </div>
+
+  {{#if this.nextRun}}
+  <div class="col-sm-3">
+    <h5>Next run</h5>
+    {{moment this.nextRun "llll"}}
+  </div>
+  {{/if}}
 </div>
 <div class="row">
   <div class="col-sm-4">


### PR DESCRIPTION
It is useful to know when delayed job scheduled for next time run.

Example:
![image](https://user-images.githubusercontent.com/418073/66266740-3162d100-e853-11e9-89b0-c8ed96b514de.png)
