### PR TITLE
Change defaultConfig require path to relative

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -16,7 +16,7 @@ module.exports = function() {
 
   const app = express();
 
-  const defaultConfig = require(path.join(__dirname, 'config', 'index.json'));
+  const defaultConfig = require('./config/index.json');
 
   const Queues = require('./queue');
 


### PR DESCRIPTION
Currently if you build the application with zeit/pkg you will not be able to run it due to a temporary snapshot path. Making it relative will allow pkg to ship the default config with the binary file.

Fixes following error:
(node:24280) UnhandledPromiseRejectionWarning: Error: Cannot find module '/snapshot/api/node_modules/bull-arena/src/server/config/index.json'
