### PR TITLE
Changes for Displaying Job logs in Job Details

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "bee-queue": "^1.0.0",
     "body-parser": "^1.17.2",
-    "bull": "^3.4.2",
+    "bull": "^3.12.1",
     "express": "^4.15.2",
     "express-handlebars": "^3.0.0",
     "handlebars": "^4.3.0",

--- a/src/server/views/dashboard/jobDetails.js
+++ b/src/server/views/dashboard/jobDetails.js
@@ -24,6 +24,8 @@ async function handler(req, res) {
     jobState = job.status;
   } else {
     jobState = await job.getState();
+    let logs = await queue.getJobLogs(job.id);
+    job.logs = (logs.logs || "No Logs");
   }
 
   return res.render('dashboard/templates/jobDetails', {

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -96,7 +96,7 @@ async function _html(req, res) {
     jobs = jobs.filter((job) => job);
   } else {
     jobs = await queue[`get${_.capitalize(state)}`](startId, endId);
-    jobs.map(async (job) => {
+    await jobs.map(async (job) => {
       let logs = await queue.getJobLogs(job.id);
       job.logs = (logs.logs || "No Logs");
       return job;

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -96,6 +96,11 @@ async function _html(req, res) {
     jobs = jobs.filter((job) => job);
   } else {
     jobs = await queue[`get${_.capitalize(state)}`](startId, endId);
+    jobs.map(async (job) => {
+      let logs = await queue.getJobLogs(job.id);
+      job.logs = (logs.logs || "No Logs");
+      return job;
+    })
   }
 
   let pages = _.range(page - 6, page + 7)

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -90,3 +90,6 @@
 
 <h5>Data</h5>
 <pre><code class="json">{{json this.data true}}</code></pre>
+
+<h5>Logs</h5>
+<pre><code class="json">{{json this.logs true}}</code></pre>


### PR DESCRIPTION
Display Job logs on the job details page. It will help to easily view the logs associated with the job while processing it.

_NOTE: Bull Queue version updated to the latest 3.12.1 since the older version does not support adding or getting logs for the Job._

![image](https://user-images.githubusercontent.com/7354687/72053305-c2cb5e80-32ec-11ea-8bae-006c8d50a463.png)