### PR TITLE
Add config options to customize title and brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ For Bee, the `redis` key will be directly passed to [`redis.createClient`](https
 
 For Bull, the `redis` key will be directly passed to [`ioredis`](https://github.com/luin/ioredis/blob/master/API.md#new_Redis_new), as explained [here](https://github.com/OptimalBits/bull/blob/master/REFERENCE.md#queue). To use this to connect to a Sentinel cluster, see [here](https://github.com/luin/ioredis/blob/master/README.md#sentinel).
 
+##### Cutomize Title and Navbar Brand
+You can change *title* and *navbar brand* of your dashboard by providing *title* and *arena* value in the root of config object:
+```js
+{
+  title: 'Your dashboard title',
+  brand: 'Your brand',
+  queues: []
+}
+```
+if not provided, *Arena* will be used as default.
+
 ##### Custom configuration file
 
 To specify a custom configuration file location, see [Running Arena as a node module](#running-arena-as-a-node-module).

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ function run(config, listenOpts = {}) {
   if (config) Queues.setConfig(config);
   Queues.useCdn = typeof listenOpts.useCdn !== 'undefined' ? listenOpts.useCdn : true;
 
+  app.locals.title = config.title || 'Arena';
+  app.locals.brand = config.brand || 'Arena';
   app.locals.appBasePath = listenOpts.basePath || app.locals.appBasePath;
 
   app.use(app.locals.appBasePath, express.static(path.join(__dirname, 'public')));

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -22,6 +22,8 @@ module.exports = function() {
 
   const queues = new Queues(defaultConfig);
   require('./views/helpers/handlebars')(handlebars, { queues });
+  app.locals.title = defaultConfig.title || 'Arena';
+  app.locals.brand = defaultConfig.brand || 'Arena';
   app.locals.Queues = queues;
   app.locals.appBasePath = '';
   app.locals.vendorPath = '/vendor';

--- a/src/server/config/index.json
+++ b/src/server/config/index.json
@@ -1,4 +1,6 @@
 {
+  "__example_title": "Arena",
+  "__example_brand": "Arena",
   "__example_queues": [
     {
       "name": "my_queue",
@@ -7,5 +9,12 @@
       "hostId": "AWS Server 2"
     }
   ],
-  "queues": []
+  "queues": [
+    {
+      "name": "my_queue",
+      "port": 6381,
+      "host": "127.0.0.1",
+      "hostId": "AWS Server 2"
+    }
+  ]
 }

--- a/src/server/views/layout.hbs
+++ b/src/server/views/layout.hbs
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Arena</title>
+    <title>{{title}}</title>
 
     {{#if (useCdn)}}
     <!-- Bootstrap core CSS -->
@@ -38,7 +38,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{{ basePath }}/">Arena</a>
+          <a class="navbar-brand" href="{{ basePath }}/">{{brand}}</a>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
Add options to customize title and navbar brand.
I would love to have this options available so I can have dashboard with may own *title* and *navbar brand* instead of the default value *Arena*