### PR TITLE
Run jobs on demand

### DIFF
--- a/src/server/queue/index.js
+++ b/src/server/queue/index.js
@@ -85,10 +85,16 @@ class Queues {
     if (queue.IS_BEE) {
       return queue.createJob(data).save();
     } else {
-      return queue.add(data, {
-        removeOnComplete: false,
-        removeOnFail: false
-      });
+      const args = [
+        data,
+        {
+          removeOnComplete: false,
+          removeOnFail: false
+        }
+      ];
+
+      if (data.name) args.unshift(data.name)
+      return queue.add.apply(queue, data);
     }
   }
 }

--- a/src/server/views/api/jobRetry.js
+++ b/src/server/views/api/jobRetry.js
@@ -12,7 +12,7 @@ async function handler(req, res) {
   try {
     const jobState = queue.IS_BEE ? job.status : await job.getState();
 
-    if(jobState === 'failed' && typeof job.retry === 'function') {
+    if (jobState === 'failed' && typeof job.retry === 'function') {
       await job.retry();
     } else {
       await Queues.set(queue, job);

--- a/src/server/views/dashboard/jobDetails.js
+++ b/src/server/views/dashboard/jobDetails.js
@@ -19,14 +19,9 @@ async function handler(req, res) {
     return res.json(_.omit(job, 'domain', 'queue', '_events', '_eventsCount'));
   }
 
-  let jobState;
-  if (queue.IS_BEE) {
-    jobState = job.status;
-  } else {
-    jobState = await job.getState();
-    let logs = await queue.getJobLogs(job.id);
-    job.logs = (logs.logs || "No Logs");
-  }
+  const jobState = queue.IS_BEE ? job.status : await job.getState();
+  job.showRetryButton = !queue.IS_BEE || jobState === 'failed';
+  job.retryButtonText = jobState === 'failed' ? 'Retry' : 'Trigger';
 
   return res.render('dashboard/templates/jobDetails', {
     basePath,

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -103,6 +103,12 @@ async function _html(req, res) {
     })
   }
 
+  for (const job of jobs) {
+    const jobState = queue.IS_BEE ? job.status : await job.getState();
+    job.showRetryButton = !queue.IS_BEE || jobState == 'failed';
+    job.retryButtonText = jobState == 'failed' ? 'Retry' : 'Trigger';
+  }
+
   let pages = _.range(page - 6, page + 7)
     .filter((page) => page >= 1);
   while (pages.length < 12) {

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -9,7 +9,7 @@
 
 {{#if showRetryButton}}
   <button class="btn btn-success js-retry-job" data-queue-host="{{ queueHost }}" data-queue-name="{{ queueName }}" data-job-id="{{ this.id }}">
-    {{retryButtonText}}
+    {{ retryButtonText }}
   </button>
 {{/if}}
 

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -7,11 +7,12 @@
   Remove
 </button>
 
-{{#eq jobState 'failed'}}
+{{#if showRetryButton}}
   <button class="btn btn-success js-retry-job" data-queue-host="{{ queueHost }}" data-queue-name="{{ queueName }}" data-job-id="{{ this.id }}">
-    Retry
+    {{retryButtonText}}
   </button>
-{{/eq}}
+{{/if}}
+
 
 <div class="row">
   <div class="col-sm-3">


### PR DESCRIPTION
We currently use [Agenda](https://github.com/agenda/agenda) paired with [AgendaDash](https://github.com/agenda/agendash). One of the features AgendaDash provides is an ability to run jobs at any time, not just when they are failed state. We consider this a core feature that any replacement should have. 

We are moving to Bull/Arena and would love this feature to be included.