### PR TITLE
Send correct data to queue

### DIFF
--- a/src/server/queue/index.js
+++ b/src/server/queue/index.js
@@ -94,7 +94,7 @@ class Queues {
       ];
 
       if (data.name) args.unshift(data.name)
-      return queue.add.apply(queue, args);
+      return queue.add(data.data, args);
     }
   }
 }


### PR DESCRIPTION
Setup:
```
"bull": "^3.13.0",
"bull-arena": "^2.8.1",
```

When retrying a completed job using the job data was being sent under the data key. This actually triggers the job with the correct data.