### PR TITLE
Add jsoneditor code and text mode options

### DIFF
--- a/src/server/views/dashboard/templates/queueDetails.hbs
+++ b/src/server/views/dashboard/templates/queueDetails.hbs
@@ -9,7 +9,7 @@
       </div>
       <div class="panel-body">
         <div class="jsoneditorx form-group hide overflow-hidden">
-          <div class="jsoneditorx hide" id="jsoneditor" style="height:200px;"></div>
+          <div class="jsoneditorx hide" id="jsoneditor" style="height:300px;"></div>
           <br />
           <div class="js-add-job  btn btn-primary btn-sm pull-right">Create</div>
         </div>
@@ -51,7 +51,7 @@
 {{/contentFor}}
 
 {{#contentFor 'script'}}
-  window.jsonEditor = new JSONEditor(document.getElementById('jsoneditor'), {});
+  window.jsonEditor = new JSONEditor(document.getElementById('jsoneditor'), { modes: ['code','tree','text'] });
   window.arenaInitialPayload = {
     queueHost: "{{ queueHost }}",
     queueName: "{{ queueName }}"


### PR DESCRIPTION
Resolves #208 and #53

Adds `code` and `text` modes to the jsoneditor. (as well as original `tree` mode)

I also expanded the jsonEditor height to 300px. More vertical space was required for `tree` mode popover prompts and `code` / `text` editor parse warn messages.

Please let me know if there is anything else I can do to get this Pull Request merged in. Thanks for the useful tool.