### PR TITLE
Fixed job listing for Bull

### DIFF
--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -101,11 +101,13 @@ async function _html(req, res) {
     jobs = jobs.filter((job) => job);
   } else {
     jobs = await queue[`get${_.capitalize(state)}`](startId, endId);
-    await Promise.all(jobs.map(async job => {
-      let logs = await queue.getJobLogs(job.id);
-      job.logs = logs.logs || 'No Logs';
-      return job;
-    }));
+    await Promise.all(
+      jobs.map(async job => {
+        const logs = await queue.getJobLogs(job.id);
+        job.logs = logs.logs || 'No Logs';
+        return job;
+      })
+    );
   }
 
   for (const job of jobs) {

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -101,13 +101,11 @@ async function _html(req, res) {
     jobs = jobs.filter((job) => job);
   } else {
     jobs = await queue[`get${_.capitalize(state)}`](startId, endId);
-    await jobs.map(
-      Promise.all(async (job) => {
-        let logs = await queue.getJobLogs(job.id);
-        job.logs = logs.logs || 'No Logs';
-        return job;
-      })
-    );
+    await Promise.all(jobs.map(async job => {
+      let logs = await queue.getJobLogs(job.id);
+      job.logs = logs.logs || 'No Logs';
+      return job;
+    }));
   }
 
   for (const job of jobs) {

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -102,7 +102,7 @@ async function _html(req, res) {
   } else {
     jobs = await queue[`get${_.capitalize(state)}`](startId, endId);
     await Promise.all(
-      jobs.map(async job => {
+      jobs.map(async (job) => {
         const logs = await queue.getJobLogs(job.id);
         job.logs = logs.logs || 'No Logs';
         return job;


### PR DESCRIPTION
When attempting to access job details by status using Bull@3.18.1 and bull-arena@3.3.2 the following exception is thrown:

```
   (node:43624) UnhandledPromiseRejectionWarning: TypeError: function is not iterable (cannot read property Symbol(Symbol.iterator))
    at Function.all (<anonymous>)
    at _html (/work/xxxxxxxx/xxxxxxxx/xxxxxxxx/node_modules/bull-arena/src/server/views/dashboard/queueJobsByState.js:105:15)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:43624) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:43624) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:43624) UnhandledPromiseRejectionWarning: TypeError: #<Promise> is not a function
    at Array.map (<anonymous>)
    at _html (/work/xxxxxxxx/xxxxxxxx/xxxxxxxx/node_modules/bull-arena/src/server/views/dashboard/queueJobsByState.js:104:16)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
(node:43624) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)

```

This PR fixes the bug on the Promise.all usage and makes the list accessible again.