### PR TITLE
Support redis connection options in BullMQ

### DIFF
--- a/src/server/queue/index.js
+++ b/src/server/queue/index.js
@@ -98,7 +98,11 @@ class Queues {
       if (queueConfig.createClient) options.createClient = queueConfig.createClient;
 
       const { BullMQ } = this._config;
-      queue = new BullMQ(name, options);
+      const { redis, ...rest } = options;
+      queue = new BullMQ(name, {
+        connection: redis,
+        ...rest,
+      });
       queue.IS_BULLMQ = true;
     } else {
       if (queueConfig.createClient) options.createClient = queueConfig.createClient;


### PR DESCRIPTION
BullMQ takes redis connections options in the format `{ connection: { host: ... }  }` instead of `{ redis: { host: ... } }`. 

This works well with connection settings as strings, havent tested passing in ioredis object