### PR TITLE
Change add job text depending on hide prop on dashboard

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -148,7 +148,11 @@ $(document).ready(() => {
   });
 
   $('.js-toggle-add-job-editor').on('click', function () {
-    $('.jsoneditorx').toggleClass('hide');
+    const addJobText = $('.js-toggle-add-job-editor').text();
+    const shouldHide = addJobText !== 'Add Job';
+    $('.jsoneditorx').toggleClass('hide', shouldHide);
+    $('.js-toggle-add-job-editor').text('Cancel');
+
     const job = localStorage.getItem('arena:savedJob');
     if (job) {
       const { name, data } = JSON.parse(job);

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -150,8 +150,9 @@ $(document).ready(() => {
   $('.js-toggle-add-job-editor').on('click', function () {
     const addJobText = $('.js-toggle-add-job-editor').text();
     const shouldHide = addJobText !== 'Add Job';
+    const newAddJobText = shouldHide ? 'Cancel' : 'Add Job';
     $('.jsoneditorx').toggleClass('hide', shouldHide);
-    $('.js-toggle-add-job-editor').text('Cancel');
+    $('.js-toggle-add-job-editor').text(newAddJobText);
 
     const job = localStorage.getItem('arena:savedJob');
     if (job) {

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -176,6 +176,7 @@ $(document).ready(() => {
       .done(() => {
         alert('Job successfully added!');
         localStorage.removeItem('arena:savedJob');
+        window.location.reload();
       })
       .fail((jqXHR) => {
         window.alert('Failed to save job, check console for error.');

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -181,7 +181,6 @@ $(document).ready(() => {
       .done(() => {
         alert('Job successfully added!');
         localStorage.removeItem('arena:savedJob');
-        window.location.reload();
       })
       .fail((jqXHR) => {
         window.alert('Failed to save job, check console for error.');

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -149,9 +149,9 @@ $(document).ready(() => {
 
   $('.js-toggle-add-job-editor').on('click', function () {
     const addJobText = $('.js-toggle-add-job-editor').text();
-    const shouldHide = addJobText !== 'Add Job';
-    const newAddJobText = shouldHide ? 'Cancel' : 'Add Job';
-    $('.jsoneditorx').toggleClass('hide', shouldHide);
+    const shouldNotHide = addJobText === 'Add Job';
+    const newAddJobText = shouldNotHide ? 'Cancel' : 'Add Job';
+    $('.jsoneditorx').toggleClass('hide', !shouldNotHide);
     $('.js-toggle-add-job-editor').text(newAddJobText);
 
     const job = localStorage.getItem('arena:savedJob');


### PR DESCRIPTION
When clicking on add job, would be nice to change the message of that button, so people would know that by clicking again, the editor will be hidden. This PR tries to handle this.