### PR TITLE
feat: add contributing guidelines and working example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+## Contributing to Arena
+
+The easiest way to get started contributing is to run the [example project](example/README.md).
+
+### Development
+
+Arena is written using Express, with simple jQuery and Handlebars on the front end.

--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ You can `docker pull` Arena from [Docker Hub](https://hub.docker.com/r/mixmaxhq/
 
 Please see the [docker-arena] repository for details.
 
-### Development
+### Contributing
 
-Arena is written using Express, with simple jQuery and Handlebars on the front end.
+See [contributing guidelines](CONTRIBUTING.md) and [an example](example/README.md).
 
 ### License
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-This is a simple demonstration of how to run Area and connect it to [Bee Queue](https://github.com/mixmaxhq/bee-queue).
+This is a simple demonstration of how to run Arena and connect it to [Bee Queue](https://github.com/mixmaxhq/bee-queue).
 
 ## Requirements
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,18 @@
+## Overview
+
+This is a simple demonstration of how to run Area and connect it to [Bee Queue](https://github.com/mixmaxhq/bee-queue).
+
+## Requirements
+
+- Node >= 7.6
+- No other services running on ports 4735 or 4736
+
+## Install
+
+`npm install`
+
+## Running
+
+`npm start`
+
+Then open http://localhost:4735/ in your browser.

--- a/example/index.js
+++ b/example/index.js
@@ -1,0 +1,46 @@
+const Arena = require('../');
+const Bee = require('bee-queue');
+const RedisServer = require('redis-server');
+
+// Select ports that are unlikely to be used by other services a developer might be running locally.
+const HTTP_SERVER_PORT = 4735;
+const REDIS_SERVER_PORT = 4736;
+
+// Create a Redis server. This is only for convenience
+
+async function main() {
+  const server = new RedisServer(REDIS_SERVER_PORT);
+  await server.open();
+
+  Arena(
+    {
+      Bee,
+
+      queues: [
+        {
+          // Required for each queue definition.
+          name: 'name_of_my_queue',
+
+          // User-readable display name for the host. Required.
+          hostId: 'Queue Server 1',
+
+          // Queue type (Bull or Bee - default Bull).
+          type: 'bee',
+
+          redis: {
+            // host: 'localhost',
+            port: REDIS_SERVER_PORT,
+          },
+        },
+      ],
+    },
+    {
+      port: HTTP_SERVER_PORT,
+    }
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "arena-example-project",
+  "version": "1.0.0",
+  "description": "An example project that uses Arena",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "bee-queue": "^1.3.1",
+    "express": "^4.17.1",
+    "redis-server": "^1.2.2"
+  }
+}


### PR DESCRIPTION
In reviewing PR https://github.com/bee-queue/arena/pull/324 I realized that there was no easy way to run the queue locally. This adds a basic working example and some simple documentation.