### PR TITLE
Apply ordering for jobs when using Bull queue

### DIFF
--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -101,7 +101,8 @@ async function _html(req, res) {
     // Filter out Bee jobs that have already been removed by the time the promise resolves
     jobs = jobs.filter((job) => job);
   } else {
-    jobs = await queue.getJobs([_.lowerCase(state)], startId, endId, order === 'asc');
+    const stateTypes = state === 'waiting' ? ['wait', 'paused'] : state;
+    jobs = await queue.getJobs(stateTypes, startId, endId, order === 'asc');
     await Promise.all(
       jobs.map(async (job) => {
         const logs = await queue.getJobLogs(job.id);

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -80,6 +80,7 @@ async function _html(req, res) {
 
   const page = parseInt(req.query.page, 10) || 1;
   const pageSize = parseInt(req.query.pageSize, 10) || 100;
+  const order = req.query.order || 'desc';
 
   const startId = (page - 1) * pageSize;
   const endId = startId + pageSize - 1;
@@ -100,7 +101,7 @@ async function _html(req, res) {
     // Filter out Bee jobs that have already been removed by the time the promise resolves
     jobs = jobs.filter((job) => job);
   } else {
-    jobs = await queue.getJobs([_.lowerCase(state)], startId, endId, false);
+    jobs = await queue.getJobs([_.lowerCase(state)], startId, endId, order === 'asc');
     await Promise.all(
       jobs.map(async (job) => {
         const logs = await queue.getJobLogs(job.id);
@@ -134,6 +135,7 @@ async function _html(req, res) {
     pages,
     pageSize,
     lastPage: _.last(pages),
+    order,
   });
 }
 

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -100,7 +100,7 @@ async function _html(req, res) {
     // Filter out Bee jobs that have already been removed by the time the promise resolves
     jobs = jobs.filter((job) => job);
   } else {
-    jobs = await queue[`get${_.capitalize(state)}`](startId, endId);
+    jobs = await queue.getJobs([_.lowerCase(state)], startId, endId, false);
     await Promise.all(
       jobs.map(async (job) => {
         const logs = await queue.getJobLogs(job.id);

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -132,6 +132,7 @@ async function _html(req, res) {
     jobs,
     jobsInStateCount: jobCounts[state],
     disablePagination: queue.IS_BEE && (state === 'succeeded' || state === 'failed'),
+    disableOrdering: queue.IS_BEE,
     currentPage: page,
     pages,
     pageSize,

--- a/src/server/views/dashboard/templates/queueJobsByState.hbs
+++ b/src/server/views/dashboard/templates/queueJobsByState.hbs
@@ -21,7 +21,7 @@
         <li {{#eq this ../currentPage}} class="active" {{/eq}}>
 
           <a
-            href="{{ ../basePath }}/{{ encodeURI ../queueHost }}/{{ encodeURI ../queueName }}/{{ ../state }}?page={{ this }}&amp;pageSize={{ ../pageSize }}&amp;order={{ order }}">{{ this }}</a>
+            href="{{ ../basePath }}/{{ encodeURI ../queueHost }}/{{ encodeURI ../queueName }}/{{ ../state }}?page={{ this }}&amp;pageSize={{ ../pageSize }}&amp;order={{ ../order }}">{{ this }}</a>
         </li>
         {{/each}}
         <li {{#eq currentPage lastPage}} class="disabled">
@@ -74,7 +74,7 @@
           <ul class="dropdown-menu">
             <li><a
                 href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ currentPage }}<&amp;order={{ order }}<&amp;pageSize={{ pageSize }}">{{ pageSize }}
-                jobs</a></li>>
+                jobs</a></li>
             <li role="separator" class="divider"></li>
             <li><a
                 href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 5 }}<&amp;order={{ order }}&amp;pageSize=5">5

--- a/src/server/views/dashboard/templates/queueJobsByState.hbs
+++ b/src/server/views/dashboard/templates/queueJobsByState.hbs
@@ -91,6 +91,7 @@
           </ul>
         </div>
       </div>
+      {{#unless disableOrdering}}
       <div class="btn-group">
         <div class="dropdown">
           <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
@@ -111,6 +112,7 @@
           </ul>
         </div>
       </div>
+      {{/unless}}
     </div>
   </div>
 </div>

--- a/src/server/views/dashboard/templates/queueJobsByState.hbs
+++ b/src/server/views/dashboard/templates/queueJobsByState.hbs
@@ -5,75 +5,113 @@
 <div class="row pagination-container">
   <div class="col-sm-6">
     {{#unless disablePagination}}
-      <nav aria-label="Job navigation">
-        <ul class="pagination">
-          <li
-            {{#eq currentPage 1}}
-              class="disabled">
-                <span>&laquo;</span>
-            {{else}}
-              ><a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ subtract currentPage 1 }}&amp;pageSize={{ pageSize }}" aria-label="Previous">
-                <span aria-hidden="true">&laquo;</span>
-              </a>
-            {{/eq}}
-          </li>
-          {{#each pages}}
-            <li
-              {{#eq this ../currentPage}}
-                class="active"
-              {{/eq}}>
+    <nav aria-label="Job navigation">
+      <ul class="pagination">
+        <li {{#eq currentPage 1}} class="disabled">
+          <span>&laquo;</span>
+          {{else}}
+          ><a
+            href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ subtract currentPage 1 }}&amp;pageSize={{ pageSize }}&amp;order={{ order }}"
+            aria-label="Previous">
+            <span aria-hidden="true">&laquo;</span>
+          </a>
+          {{/eq}}
+        </li>
+        {{#each pages}}
+        <li {{#eq this ../currentPage}} class="active" {{/eq}}>
 
-              <a href="{{ ../basePath }}/{{ encodeURI ../queueHost }}/{{ encodeURI ../queueName }}/{{ ../state }}?page={{ this }}&amp;pageSize={{ ../pageSize }}">{{ this }}</a>
-            </li>
-          {{/each}}
-          <li
-            {{#eq currentPage lastPage}}
-              class="disabled">
-                <span>&raquo;</span>
-            {{else}}
-              ><a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ add currentPage 1 }}&amp;pageSize={{ pageSize }}" aria-label="Previous">
-                <span aria-hidden="true">&raquo;</span>
-              </a>
-            {{/eq}}
-          </li>
-        </ul>
-      </nav>
+          <a
+            href="{{ ../basePath }}/{{ encodeURI ../queueHost }}/{{ encodeURI ../queueName }}/{{ ../state }}?page={{ this }}&amp;pageSize={{ ../pageSize }}&amp;order={{ order }}">{{ this }}</a>
+        </li>
+        {{/each}}
+        <li {{#eq currentPage lastPage}} class="disabled">
+          <span>&raquo;</span>
+          {{else}}
+          ><a
+            href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ add currentPage 1 }}&amp;pageSize={{ pageSize }}&amp;order={{ order }}"
+            aria-label="Previous">
+            <span aria-hidden="true">&raquo;</span>
+          </a>
+          {{/eq}}
+        </li>
+      </ul>
+    </nav>
     {{else}}
-      Bee-queue does not support pagination for {{ state }} queues &mdash; currently displaying up to <b>{{ pageSize }} jobs</b>. To change count, use "Size" dropdown.
+    Bee-queue does not support pagination for {{ state }} queues &mdash; currently displaying up to <b>{{ pageSize }}
+      jobs</b>. To change count, use "Size" dropdown.
     {{/unless}}
   </div>
   <div class="col-sm-6 text-right">
-    <a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}.json" type="button" class="btn btn-primary">
+    <a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}.json" type="button"
+      class="btn btn-primary">
       Dump jobs to JSON (limited to 1000)
     </a>
-    <button type="button" data-action="remove" data-queue-name="{{ queueName }}" data-queue-host="{{ queueHost }}" data-queue-state="{{ state }}" class="js-bulk-action btn btn-danger">
+    <button type="button" data-action="remove" data-queue-name="{{ queueName }}" data-queue-host="{{ queueHost }}"
+      data-queue-state="{{ state }}" class="js-bulk-action btn btn-danger">
       Remove Jobs
     </button>
     {{#eq state 'failed'}}
-      <button type="button" data-action="retry" data-queue-name="{{ queueName }}" data-queue-host="{{ queueHost }}" data-queue-state="{{ state }}" class="js-bulk-action btn btn-success">
-        Retry Jobs
-      </button>
+    <button type="button" data-action="retry" data-queue-name="{{ queueName }}" data-queue-host="{{ queueHost }}"
+      data-queue-state="{{ state }}" class="js-bulk-action btn btn-success">
+      Retry Jobs
+    </button>
     {{/eq}}
 
+    <div class="btn-group">
       <div class="btn-group">
-        {{#if disablePagination}}
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <div class="dropdown">
+          {{#if disablePagination}}
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
+            aria-expanded="false">
             Size <span class="caret"></span>
           </button>
-        {{else}}
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          {{else}}
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
+            aria-expanded="false">
             Page Size <span class="caret"></span>
           </button>
-        {{/if}}
-        <ul class="dropdown-menu">
-          <li><a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ currentPage }}&amp;pageSize={{ pageSize }}">{{ pageSize }} jobs</a></li>
-          <li role="separator" class="divider"></li>
-          <li><a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 5 }}&amp;pageSize=5">5 jobs</a></li>
-          <li><a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 20 }}&amp;pageSize=20">20 jobs</a></li>
-          <li><a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 100 }}&amp;pageSize=100">100 jobs</a></li>
-          <li><a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 1000 }}&amp;pageSize=1000">1000 jobs</a></li>
-        </ul>
+          {{/if}}
+          <ul class="dropdown-menu">
+            <li><a
+                href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ currentPage }}<&amp;order={{ order }}<&amp;pageSize={{ pageSize }}">{{ pageSize }}
+                jobs</a></li>>
+            <li role="separator" class="divider"></li>
+            <li><a
+                href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 5 }}<&amp;order={{ order }}&amp;pageSize=5">5
+                jobs</a></li>
+            <li><a
+                href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 20 }}<&amp;order={{ order }}&amp;pageSize=20">20
+                jobs</a></li>
+            <li><a
+                href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 100 }}<&amp;order={{ order }}&amp;pageSize=100">100
+                jobs</a></li>
+            <li><a
+                href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ adjustedPage currentPage pageSize 1000 }}<&amp;order={{ order }}&amp;pageSize=1000">1000
+                jobs</a></li>
+          </ul>
+        </div>
       </div>
+      <div class="btn-group">
+        <div class="dropdown">
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
+            aria-expanded="false">
+            Order <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <li><a
+                href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ currentPage }}&amp;pageSize={{ pageSize }}&amp;order={{ order }}">{{ order }}
+              </a></li>
+            <li role="separator" class="divider"></li>
+            <li><a
+                href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ currentPage }}&amp;pageSize={{ pageSize }}&amp;order=asc">acs
+              </a></li>
+            <li><a
+                href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ state }}?page={{ currentPage }}&amp;pageSize={{ pageSize }}&amp;order=desc">desc
+              </a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -87,28 +125,28 @@
         </li>
 
         {{#each jobs}}
-          <li class="list-group-item">
-            <div class="js-bulk-action-container bulk-job-container">
-              <input type="hidden" name="jobId" value="{{ this.id }}" />
-              <input class="js-bulk-job" name="jobChecked" type="checkbox" />
-            </div>
+        <li class="list-group-item">
+          <div class="js-bulk-action-container bulk-job-container">
+            <input type="hidden" name="jobId" value="{{ this.id }}" />
+            <input class="js-bulk-job" name="jobChecked" type="checkbox" />
+          </div>
 
-            <a role="button" data-toggle="collapse" href="#collapse{{hashIdAttr this}}">
-              <h4 class="header-collapse">
-                <span class="label label-default">{{#if this.id}}{{ this.id }}{{else}}<em>missing id</em>{{/if}}</span>
-                {{#if this.data.arenaName}}
-                  <span style="margin-left: 8px">{{ this.data.arenaName }}</span>
-                {{else if this.name}}
-                  <span style="margin-left: 8px">{{ this.name }}</span>
-                {{else if this.data.name}}
-                  <span style="margin-left: 8px">{{ this.data.name }}</span>
-                {{/if}}
-              </h4>
-            </a>
-            <div id="collapse{{hashIdAttr this}}" class="collapse">
-              {{~> dashboard/jobDetails this basePath=../basePath displayJobInline=true queueName=../queueName queueHost=../queueHost jobState=../state }}
-            </div>
-          </li>
+          <a role="button" data-toggle="collapse" href="#collapse{{hashIdAttr this}}">
+            <h4 class="header-collapse">
+              <span class="label label-default">{{#if this.id}}{{ this.id }}{{else}}<em>missing id</em>{{/if}}</span>
+              {{#if this.data.arenaName}}
+              <span style="margin-left: 8px">{{ this.data.arenaName }}</span>
+              {{else if this.name}}
+              <span style="margin-left: 8px">{{ this.name }}</span>
+              {{else if this.data.name}}
+              <span style="margin-left: 8px">{{ this.data.name }}</span>
+              {{/if}}
+            </h4>
+          </a>
+          <div id="collapse{{hashIdAttr this}}" class="collapse">
+            {{~> dashboard/jobDetails this basePath=../basePath displayJobInline=true queueName=../queueName queueHost=../queueHost jobState=../state }}
+          </div>
+        </li>
         {{/each}}
       </ul>
     </form>
@@ -116,11 +154,13 @@
 </div>
 
 <p>
-  <em>Hint: </em><kbd><span style="font-family: sans-serif;">&#8679;</span> + Click</kbd><em> to select a range of jobs.</em>
+  <em>Hint: </em><kbd><span style="font-family: sans-serif;">&#8679;</span> + Click</kbd><em> to select a range of
+    jobs.</em>
 </p>
 
 {{#contentFor 'sidebar'}}
-  <li><a href="{{ basePath }}/">Queues Overview</a></li>
-  <li><a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}">Queue <code>{{ queueHost }}/{{ queueName }}</code></a></li>
-  <li class="active"><a href="#">{{capitalize state}} Jobs</a></li>
+<li><a href="{{ basePath }}/">Queues Overview</a></li>
+<li><a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}">Queue
+    <code>{{ queueHost }}/{{ queueName }}</code></a></li>
+<li class="active"><a href="#">{{capitalize state}} Jobs</a></li>
 {{/contentFor}}


### PR DESCRIPTION
When showing the jobs list by state, would be nice to have the last created jobs at the top, this PR tries to handle that by applying ordering desc by default. Also I added a dropdown for ordering so a user could choose how to order jobs by id
#240 
tested with #326 

![Selection_002](https://user-images.githubusercontent.com/14021523/108631855-040fc680-743a-11eb-9fb6-1fcc52ba78e7.png)
![Selection_003](https://user-images.githubusercontent.com/14021523/108631859-083be400-743a-11eb-94ad-357255272f28.png)
![Selection_004](https://user-images.githubusercontent.com/14021523/108631862-0bcf6b00-743a-11eb-88bb-380228d037fa.png)
![Selection_005](https://user-images.githubusercontent.com/14021523/108631864-0e31c500-743a-11eb-8d91-06d7a674393f.png)
![Selection_006](https://user-images.githubusercontent.com/14021523/108631866-10941f00-743a-11eb-9f48-06097fe24593.png)
