### PR TITLE
Fix performance in job details

### DIFF
--- a/example/bull.js
+++ b/example/bull.js
@@ -30,7 +30,8 @@ async function main() {
   });
 
   // adding delayed jobs
-  await queue.add({}, { delay: Date.now() + 60 * 1000 });
+  const delayedJob = await queue.add({}, { delay: Date.now() + 60 * 1000 });
+  delayedJob.log('Log message');
 
   Arena(
     {

--- a/src/server/views/dashboard/jobDetails.js
+++ b/src/server/views/dashboard/jobDetails.js
@@ -30,6 +30,11 @@ async function handler(req, res) {
   job.retryButtonText = jobState === 'failed' ? 'Retry' : 'Trigger';
   const stacktraces = queue.IS_BEE ? job.options.stacktraces : job.stacktrace;
 
+  if (!queue.IS_BEE) {
+    const logs = await queue.getJobLogs(job.id);
+    job.logs = logs.logs || 'No Logs';
+  }
+
   return res.render('dashboard/templates/jobDetails', {
     basePath,
     queueName,

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -103,13 +103,6 @@ async function _html(req, res) {
   } else {
     const stateTypes = state === 'waiting' ? ['wait', 'paused'] : state;
     jobs = await queue.getJobs(stateTypes, startId, endId, order === 'asc');
-    await Promise.all(
-      jobs.map(async (job) => {
-        const logs = await queue.getJobLogs(job.id);
-        job.logs = logs.logs || 'No Logs';
-        return job;
-      })
-    );
   }
 
   for (const job of jobs) {

--- a/src/server/views/helpers/handlebars.js
+++ b/src/server/views/helpers/handlebars.js
@@ -18,6 +18,18 @@ const replacer = (key, value) => {
 // For jobs that don't have a valid ID, produce a random ID we can use in its place.
 const idMapping = new WeakMap();
 
+const getTimestamp = (job) => {
+  // Bull
+  if (job.timestamp) {
+    return job.timestamp;
+  }
+
+  // Bee
+  if (job.options && job.options.timestamp) {
+    return job.options.timestamp;
+  }
+};
+
 const helpers = {
   json(obj, pretty = false) {
     const args = [obj, replacer];
@@ -62,20 +74,18 @@ const helpers = {
   },
 
   getDelay(job) {
+    // Bull
     if (job.delay) {
-      return job.delay;
+      return job.delay + getTimestamp(job);
     }
 
-    return job.options ? job.options.delay : undefined;
-  },
-
-  getTimestamp(job) {
-    if (job.timestamp) {
-      return job.timestamp;
+    // Bee
+    if (job.options && job.options.delay) {
+      return job.options.delay + getTimestamp(job);
     }
-
-    return job.options ? job.options.timestamp : undefined;
   },
+
+  getTimestamp,
 
   encodeURI(url) {
     if (typeof url !== 'string') {

--- a/src/server/views/helpers/handlebars.js
+++ b/src/server/views/helpers/handlebars.js
@@ -61,8 +61,20 @@ const helpers = {
     return mapping;
   },
 
+  getDelay(job) {
+    if (job.delay) {
+      return job.delay;
+    }
+
+    return job.options ? job.options.delay : undefined;
+  },
+
   getTimestamp(job) {
-    return job.timestamp ? job.timestamp : job.options.timestamp;
+    if (job.timestamp) {
+      return job.timestamp;
+    }
+
+    return job.options ? job.options.timestamp : undefined;
   },
 
   encodeURI(url) {

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -46,7 +46,7 @@
   {{#if (getDelay this)}}
   <div class="col-sm-3">
     <h5>Executes At</h5>
-    {{moment (add (getDelay this) (getTimestamp this) ) "llll"}}
+    {{moment (getDelay this) "llll"}}
   </div>
   {{/if}}
 

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -24,10 +24,8 @@
 
   <div class="col-sm-3">
     <h5>Timestamp</h5>
-    {{#if this.options.timestamp}}
-    {{moment this.options.timestamp "llll"}}
-    {{else if this.timestamp}}
-    {{moment this.timestamp "llll"}}
+    {{#if (getTimestamp this)}}
+    {{moment (getTimestamp this) "llll"}}
     {{/if}}
   </div>
 
@@ -45,15 +43,10 @@
   </div>
   {{/if}}
 
-  {{#if this.delay}}
+  {{#if (getDelay this)}}
   <div class="col-sm-3">
     <h5>Executes At</h5>
-    {{moment (add this.delay (getTimestamp this) ) "llll"}}
-  </div>
-  {{else if this.options.delay}}
-  <div class="col-sm-3">
-    <h5>Executes At</h5>
-    {{moment (add this.options.delay (getTimestamp this) ) "llll"}}
+    {{moment (add (getDelay this) (getTimestamp this) ) "llll"}}
   </div>
   {{/if}}
 
@@ -114,5 +107,7 @@
 <h5>Data</h5>
 <pre><code class="json">{{json this.data true}}</code></pre>
 
+{{#if this.logs}}
 <h5>Logs</h5>
 <pre><code class="json">{{json this.logs true}}</code></pre>
+{{/if}}


### PR DESCRIPTION
In order to prevent a loading time when we have 1000 jobs in our tables, we could just show the logs when we click in job button for standalone page, this PR should solve #220 