### PR TITLE
Brad/fix executes at

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -19,4 +19,4 @@ or
 
 `npm run start:bull`
 
-Then open http://localhost:4735/ in your browser.
+Then open http://localhost:4735 in your browser.

--- a/example/bee.js
+++ b/example/bee.js
@@ -13,6 +13,7 @@ async function main() {
   await server.open();
 
   const queue = new Bee('name_of_my_queue', {
+    activateDelayedJobs: true,
     redis: {
       port: REDIS_SERVER_PORT,
     },

--- a/example/bull.js
+++ b/example/bull.js
@@ -30,7 +30,7 @@ async function main() {
   });
 
   // adding delayed jobs
-  const delayedJob = await queue.add({}, { delay: Date.now() + 60 * 1000 });
+  const delayedJob = await queue.add({}, { delay: 60 * 1000 });
   delayedJob.log('Log message');
 
   Arena(

--- a/src/server/views/helpers/handlebars.js
+++ b/src/server/views/helpers/handlebars.js
@@ -73,7 +73,7 @@ const helpers = {
     return mapping;
   },
 
-  getDelay(job) {
+  getDelayedExectionAt(job) {
     // Bull
     if (job.delay) {
       return job.delay + getTimestamp(job);
@@ -81,7 +81,7 @@ const helpers = {
 
     // Bee
     if (job.options && job.options.delay) {
-      return job.options.delay + getTimestamp(job);
+      return job.options.delay;
     }
   },
 

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -43,12 +43,12 @@
   </div>
   {{/if}}
 
-  {{#if (getDelay this)}}
+  {{#eq jobState 'delayed'}}
   <div class="col-sm-3">
     <h5>Executes At</h5>
-    {{moment (getDelay this) "llll"}}
+    {{moment (getDelayedExectionAt this) "llll"}}
   </div>
-  {{/if}}
+  {{/eq}}
 
   <div class="col-sm-3">
     <h5>Attempts Made</h5>

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -31,14 +31,14 @@
 
   {{#if this.processedOn}}
   <div class="col-sm-3">
-    <h5>Processed On</h5>
+    <h5>Processed</h5>
     {{moment this.processedOn "llll"}}
   </div>
   {{/if}}
 
   {{#if this.finishedOn}}
   <div class="col-sm-3">
-    <h5>Finished On</h5>
+    <h5>Finished</h5>
     {{moment this.finishedOn "llll"}}
   </div>
   {{/if}}


### PR DESCRIPTION
Changes:
Fixes regression https://github.com/bee-queue/arena/issues/348 and https://github.com/bee-queue/arena/issues/145

Test plan:
- [ ] From the `examples` dir, run `npm run start:bee`. Load http://localhost:4735. Click the delayed job. It should show 'executes at' with a date showing one minute late. Let the job execute and open it in the 'active' state. It should not show "executes at".
- [ ] Repeat above example except run `npm run start:bull`.