### PR TITLE
Adding Promote Jobs button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ package-lock.json
 .idea
 *.tern-port
 *.sublime-workspace
+dump.rdb

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -169,7 +169,9 @@ $(document).ready(() => {
         method: action === 'remove' ? 'POST' : 'PATCH',
         url: `${basePath}/api/queue/${encodeURIComponent(
           queueHost
-        )}/${encodeURIComponent(queueName)}/job/bulk`,
+        )}/${encodeURIComponent(queueName)}/${
+          action === 'promote' ? 'delayed/' : ''
+        }job/bulk`,
         data: JSON.stringify(data),
         contentType: 'application/json',
       })

--- a/src/server/views/api/bulkAction.js
+++ b/src/server/views/api/bulkAction.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-const ACTIONS = ['remove', 'retry'];
+const ACTIONS = ['remove', 'retry', 'promote'];
 
 function bulkAction(action) {
   return async function handler(req, res) {

--- a/src/server/views/api/bulkJobsPromote.js
+++ b/src/server/views/api/bulkJobsPromote.js
@@ -1,0 +1,3 @@
+const bulkAction = require('./bulkAction');
+
+module.exports = bulkAction('promote');

--- a/src/server/views/api/index.js
+++ b/src/server/views/api/index.js
@@ -4,12 +4,14 @@ const jobAdd = require('./jobAdd');
 const jobPromote = require('./jobPromote');
 const jobRetry = require('./jobRetry');
 const jobRemove = require('./jobRemove');
+const bulkJobsPromote = require('./bulkJobsPromote');
 const bulkJobsRemove = require('./bulkJobsRemove');
 const bulkJobsRetry = require('./bulkJobsRetry');
 
 router.post('/queue/:queueHost/:queueName/job', jobAdd);
 router.post('/queue/:queueHost/:queueName/job/bulk', bulkJobsRemove);
 router.patch('/queue/:queueHost/:queueName/job/bulk', bulkJobsRetry);
+router.patch('/queue/:queueHost/:queueName/delayed/job/bulk', bulkJobsPromote);
 router.patch('/queue/:queueHost/:queueName/delayed/job/:id', jobPromote);
 router.patch('/queue/:queueHost/:queueName/job/:id', jobRetry);
 router.delete('/queue/:queueHost/:queueName/job/:id', jobRemove);

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -121,6 +121,7 @@ async function _html(req, res) {
     pages.push(_.last(pages) + 1);
   }
   pages = pages.filter((page) => page <= _.ceil(jobCounts[state] / pageSize));
+  const disablePromote = !(state === 'delayed' && !queue.IS_BEE);
   const disableRetry = !(
     state === 'failed' ||
     (state === 'delayed' && !queue.IS_BEE)
@@ -136,6 +137,7 @@ async function _html(req, res) {
     disablePagination:
       queue.IS_BEE && (state === 'succeeded' || state === 'failed'),
     disableOrdering: queue.IS_BEE,
+    disablePromote,
     disableRetry,
     currentPage: page,
     pages,

--- a/src/server/views/dashboard/templates/queueJobsByState.hbs
+++ b/src/server/views/dashboard/templates/queueJobsByState.hbs
@@ -56,6 +56,12 @@
       Retry Jobs
     </button>
     {{/unless}}
+    {{#unless disablePromote}}
+    <button type="button" data-action="promote" data-queue-name="{{ queueName }}" data-queue-host="{{ queueHost }}"
+      data-queue-state="{{ state }}" class="js-bulk-action btn btn-success">
+      Promote Jobs
+    </button>
+    {{/unless}}
 
     <div class="btn-group">
       <div class="btn-group">


### PR DESCRIPTION
#### Changes Made
This is a new feature to allow us to promote multiple delayed jobs by Promote Jobs button. #203 
#### Potential Risks
This feature is only allowed in Bull and Bullmq
#### Test Plan
1. go to example directory and run: npm run start:bull
2. go to delayed table
3. check the delayed job
4. click on Promote Jobs button
5. check the the delayed job, now is in active table

#### Checklist

- [ ] I've increased test coverage
- [ ] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
