### PR TITLE
Support waiting-children state for bullmq

### DIFF
--- a/example/bullmq.js
+++ b/example/bullmq.js
@@ -1,5 +1,5 @@
 const Arena = require('../');
-const {Queue, QueueScheduler, Worker} = require('bullmq');
+const {Queue, QueueScheduler, Worker, FlowProducer} = require('bullmq');
 const RedisServer = require('redis-server');
 
 // Select ports that are unlikely to be used by other services a developer might be running locally.
@@ -12,6 +12,7 @@ async function main() {
   const server = new RedisServer(REDIS_SERVER_PORT);
   await server.open();
   const queueName = 'name_of_my_queue';
+  const parentQueueName = 'name_of_my_parent_queue';
 
   const queueScheduler = new QueueScheduler(queueName, {
     connection: {port: REDIS_SERVER_PORT},
@@ -19,6 +20,13 @@ async function main() {
   await queueScheduler.waitUntilReady();
 
   const queue = new Queue(queueName, {
+    connection: {port: REDIS_SERVER_PORT},
+  });
+  new Queue(parentQueueName, {
+    connection: {port: REDIS_SERVER_PORT},
+  });
+
+  const flow = new FlowProducer({
     connection: {port: REDIS_SERVER_PORT},
   });
 
@@ -38,6 +46,33 @@ async function main() {
     }
   );
 
+  new Worker(
+    parentQueueName,
+    async function () {
+      // Wait 10sec
+      await new Promise((res) => setTimeout(res, 10000));
+
+      // Randomly succeeds or fails the job to put some jobs in completed and some in failed.
+      if (Math.random() > 0.5) {
+        throw new Error('fake error');
+      }
+    },
+    {
+      connection: {port: REDIS_SERVER_PORT},
+    }
+  );
+
+  await flow.add({
+    name: 'parent-job',
+    queueName: parentQueueName,
+    data: {},
+    children: [
+      {name: 'child', data: {idx: 0, foo: 'bar'}, queueName},
+      {name: 'child', data: {idx: 1, foo: 'baz'}, queueName},
+      {name: 'child', data: {idx: 2, foo: 'qux'}, queueName},
+    ],
+  });
+
   // adding delayed jobs
   const delayedJob = await queue.add('delayed', {}, {delay: 60 * 1000});
   delayedJob.log('Log message');
@@ -49,10 +84,25 @@ async function main() {
       queues: [
         {
           // Required for each queue definition.
-          name: 'name_of_my_queue',
+          name: queueName,
 
           // User-readable display name for the host. Required.
           hostId: 'Queue Server 1',
+
+          // Queue type (Bull or Bullmq or Bee - default Bull).
+          type: 'bullmq',
+
+          redis: {
+            // host: 'localhost',
+            port: REDIS_SERVER_PORT,
+          },
+        },
+        {
+          // Required for each queue definition.
+          name: parentQueueName,
+
+          // User-readable display name for the host. Required.
+          hostId: 'Queue Server 2',
 
           // Queue type (Bull or Bullmq or Bee - default Bull).
           type: 'bullmq',

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bee-queue": "^1.3.1",
     "bull": "^3.20.1",
-    "bullmq": "^1.15.1",
+    "bullmq": "^1.26.2",
     "express": "^4.17.1",
     "redis-server": "^1.2.2"
   }

--- a/src/server/views/dashboard/index.js
+++ b/src/server/views/dashboard/index.js
@@ -8,7 +8,7 @@ const jobDetails = require('./jobDetails');
 router.get('/', queueList);
 router.get('/:queueHost/:queueName', queueDetails);
 router.get(
-  '/:queueHost/:queueName/:state(waiting|active|completed|succeeded|failed|delayed).:ext?',
+  '/:queueHost/:queueName/:state(waiting|active|completed|succeeded|failed|delayed|waiting-children).:ext?',
   queueJobsByState
 );
 router.get('/:queueHost/:queueName/:id', jobDetails);

--- a/src/server/views/dashboard/queueDetails.js
+++ b/src/server/views/dashboard/queueDetails.js
@@ -17,7 +17,7 @@ async function handler(req, res) {
     jobCounts = await queue.checkHealth();
     delete jobCounts.newestJob;
   } else if (queue.IS_BULLMQ) {
-    jobCounts = await queue.getJobCounts(...QueueHelpers.BULL_STATES);
+    jobCounts = await queue.getJobCounts(...QueueHelpers.BULLMQ_STATES);
   } else {
     jobCounts = await queue.getJobCounts();
   }

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -5,11 +5,11 @@ const {
   BULLMQ_STATES,
 } = require('../helpers/queueHelpers');
 
-function getStates(isBee, isBullmq) {
-  if (isBee) {
+function getStates(queue) {
+  if (queue.IS_BEE) {
     return BEE_STATES;
   }
-  if (isBullmq) {
+  if (queue.IS_BULLMQ) {
     return BULLMQ_STATES;
   }
   return BULL_STATES;
@@ -18,13 +18,12 @@ function getStates(isBee, isBullmq) {
  * Determines if the requested job state lookup is valid.
  *
  * @param {String} state
- * @param {Boolean} isBee States vary between bull, bullmq and bee
- * @param {Boolean} isBullMq States vary between bull, bullmq and bee
+ * @param {Object} queue Queue that contains which queue package is used (bee, bull or bullmq)
  *
  * @return {Boolean}
  */
-function isValidState(state, isBee, isBullMq) {
-  const validStates = getStates(isBee, isBullMq);
+function isValidState(state, queue) {
+  const validStates = getStates(queue);
   return _.includes(validStates, state);
 }
 
@@ -46,7 +45,7 @@ async function _json(req, res) {
   const queue = await Queues.get(queueName, queueHost);
   if (!queue) return res.status(404).json({message: 'Queue not found'});
 
-  if (!isValidState(state, queue.IS_BEE, queue.IS_BULLMQ))
+  if (!isValidState(state, queue))
     return res.status(400).json({message: `Invalid state requested: ${state}`});
 
   let jobs;
@@ -87,7 +86,7 @@ async function _html(req, res) {
       queueHost,
     });
 
-  if (!isValidState(state, queue.IS_BEE, queue.IS_BULLMQ))
+  if (!isValidState(state, queue))
     return res.status(400).json({message: `Invalid state requested: ${state}`});
 
   let jobCounts;

--- a/src/server/views/helpers/queueHelpers.js
+++ b/src/server/views/helpers/queueHelpers.js
@@ -64,6 +64,18 @@ const Helpers = {
    * Valid states for a job in bull queue
    */
   BULL_STATES: ['waiting', 'active', 'completed', 'failed', 'delayed'],
+
+  /**
+   * Valid states for a job in bullmq queue
+   */
+  BULLMQ_STATES: [
+    'waiting',
+    'active',
+    'completed',
+    'failed',
+    'delayed',
+    'waiting-children',
+  ],
 };
 
 module.exports = Helpers;


### PR DESCRIPTION
#### Changes Made
This PR adds a new state that is supported in bullmq: waiting-children, also is added the example into the example bullmq file.
#### Potential Risks
It's suppose to add a new bullmq state so should only be related to see in the example

#### Test Plan
Go to example directory and run: npm run start:bullmq
There are 2 queues, parentQueue should have 1 job in waiting-children state
If some of the children fails, we can retry those with the retry button
when those children are completed, the parent job in parentQueue should be processed

#### Checklist

- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
