### PR TITLE
Add parent children to job details

### DIFF
--- a/example/bullmq_with_flows.js
+++ b/example/bullmq_with_flows.js
@@ -95,7 +95,7 @@ async function main() {
           name: parentQueueName,
 
           // User-readable display name for the host. Required.
-          hostId: 'Queue Server 2',
+          hostId: 'Queue Server 1',
 
           // Queue type (Bull or Bullmq or Bee - default Bull).
           type: 'bullmq',

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -69,12 +69,6 @@ $(document).ready(() => {
     }
   });
 
-  // Set up individual "click on job link" handler
-  $('.js-job-link').on('click', function (e) {
-    e.preventDefault();
-    console.log('job clicked');
-  });
-
   // Set up individual "remove job" handler
   $('.js-remove-job').on('click', function (e) {
     e.preventDefault();

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -69,6 +69,12 @@ $(document).ready(() => {
     }
   });
 
+  // Set up individual "click on job link" handler
+  $('.js-job-link').on('click', function (e) {
+    e.preventDefault();
+    console.log('job clicked');
+  });
+
   // Set up individual "remove job" handler
   $('.js-remove-job').on('click', function (e) {
     e.preventDefault();

--- a/src/server/views/dashboard/queueJobsByState.js
+++ b/src/server/views/dashboard/queueJobsByState.js
@@ -130,14 +130,7 @@ async function _html(req, res) {
     job.showRetryButton = !queue.IS_BEE || jobState === 'failed';
     job.retryButtonText = jobState === 'failed' ? 'Retry' : 'Trigger';
     job.showPromoteButton = !queue.IS_BEE && jobState === 'delayed';
-    job.parentJobId = JobHelpers.getJobId(job.parentKey);
-    const {processed, unprocessed} = await job.getDependencies();
-    if (unprocessed) {
-      job.children = unprocessed.map((child) => JobHelpers.getJobId(child));
-    }
-    _.forOwn(processed, function (value, key) {
-      job.children.push(JobHelpers.getJobId(key));
-    });
+    job.parent = JobHelpers.getKeyProperties(job.parentKey);
   }
 
   let pages = _.range(page - 6, page + 7).filter((page) => page >= 1);

--- a/src/server/views/helpers/jobHelpers.js
+++ b/src/server/views/helpers/jobHelpers.js
@@ -1,7 +1,12 @@
 const Helpers = {
-  getJobId: function (jobData) {
+  getKeyProperties: function (jobData) {
     if (!jobData) return '';
-    return jobData.substring(jobData.lastIndexOf(':') + 1, jobData.length);
+    const [, queueName, id] = jobData.split(':');
+
+    return {
+      id,
+      queueName,
+    };
   },
 };
 

--- a/src/server/views/helpers/jobHelpers.js
+++ b/src/server/views/helpers/jobHelpers.js
@@ -1,0 +1,8 @@
+const Helpers = {
+  getJobId: function (jobData) {
+    if (!jobData) return '';
+    return jobData.substring(jobData.lastIndexOf(':') + 1, jobData.length);
+  },
+};
+
+module.exports = Helpers;

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -128,6 +128,33 @@
 <h5>Data</h5>
 <pre><code class="json">{{json this.data true}}</code></pre>
 
+<div class="row">
+  <div class="col-sm-12">
+    <h5>Parent</h5>
+    <a href="">
+      <span class="label label-default js-job-link">{{#if this.parentJobId}}{{ this.parentJobId }}{{else}}<em>No parent
+          job</em>{{/if}}</span>
+    </a>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-12">
+    <h5>Children</h5>
+
+    {{#if this.children}}
+    {{#each this.children}}
+    <a href="">
+      <span class="label label-default js-job-link">{{ this }}</span>
+    </a>
+    {{/each}}
+    {{else}}
+    <span class="label label-default"><em>No children jobs</em></span>
+    {{/if}}
+  </div>
+</div>
+<br>
+
 {{#if this.logs}}
 <h5>Logs</h5>
 <pre><code class="json">{{json this.logs true}}</code></pre>

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -128,32 +128,47 @@
 <h5>Data</h5>
 <pre><code class="json">{{json this.data true}}</code></pre>
 
+{{#if this.queue.IS_BULLMQ}}
+{{#if this.parent }}
 <div class="row">
   <div class="col-sm-12">
     <h5>Parent</h5>
-    <a href="">
-      <span class="label label-default js-job-link">{{#if this.parentJobId}}{{ this.parentJobId }}{{else}}<em>No parent
-          job</em>{{/if}}</span>
+    <a href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI this.parent.queueName }}/{{ this.parent.id }}">
+      <span class="label label-default">{{ this.parent.id }}</span>
     </a>
   </div>
 </div>
+{{/if}}
 
+{{#if this.unprocessedChildren }}
 <div class="row">
   <div class="col-sm-12">
-    <h5>Children</h5>
+    <h5>Unprocessed Children</h5>
 
-    {{#if this.children}}
-    {{#each this.children}}
-    <a href="">
-      <span class="label label-default js-job-link">{{ this }}</span>
+    {{#each this.unprocessedChildren}}
+    <a href="{{ ../basePath }}/{{ encodeURI ../queueHost }}/{{ encodeURI this.queueName }}/{{ this.id }}">
+      <span class="label label-danger">{{ this.id }}</span>
     </a>
     {{/each}}
-    {{else}}
-    <span class="label label-default"><em>No children jobs</em></span>
-    {{/if}}
   </div>
 </div>
+{{/if}}
+
+{{#if this.processedChildren }}
+<div class="row">
+  <div class="col-sm-12">
+    <h5>Processed Children</h5>
+
+    {{#each this.processedChildren}}
+    <a href="{{ ../basePath }}/{{ encodeURI ../queueHost }}/{{ encodeURI this.queueName }}/{{ this.id }}">
+      <span class="label label-success">{{ this.id }}</span>
+    </a>
+    {{/each}}
+  </div>
+</div>
+{{/if}}
 <br>
+{{/if}}
 
 {{#if this.logs}}
 <h5>Logs</h5>


### PR DESCRIPTION
#### Changes Made

Adding parentId and children info on JobDetails and QueueJobsByState views.

#### Potential Risks

No potential risks

#### Test Plan

1. Run the example `npm run start:bullmq_with_flows`
2. Go to the parent queue, and when clicking on the job details, two new sections will appear: parent and children, from which we can navigate to the respective parent and children.

#### Checklist

- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.

