### PR TITLE
Use pagination with children

### DIFF
--- a/example/bullmq_with_flows.js
+++ b/example/bullmq_with_flows.js
@@ -29,6 +29,7 @@ async function main() {
     queueName,
     async function () {
       // Wait 5sec
+      return 1;
       await new Promise((res) => setTimeout(res, 5000));
 
       // Randomly succeeds or fails the job to put some jobs in completed and some in failed.
@@ -57,15 +58,16 @@ async function main() {
     }
   );
 
+  const children = Array.from(Array(65).keys()).map((index) => ({
+    name: 'child',
+    data: {idx: index, foo: 'bar'},
+    queueName,
+  }));
   await flow.add({
     name: 'parent-job',
     queueName: parentQueueName,
     data: {},
-    children: [
-      {name: 'child', data: {idx: 0, foo: 'bar'}, queueName},
-      {name: 'child', data: {idx: 1, foo: 'baz'}, queueName},
-      {name: 'child', data: {idx: 2, foo: 'qux'}, queueName},
-    ],
+    children,
   });
 
   Arena(

--- a/example/bullmq_with_flows.js
+++ b/example/bullmq_with_flows.js
@@ -29,7 +29,6 @@ async function main() {
     queueName,
     async function () {
       // Wait 5sec
-      return 1;
       await new Promise((res) => setTimeout(res, 5000));
 
       // Randomly succeeds or fails the job to put some jobs in completed and some in failed.
@@ -58,16 +57,15 @@ async function main() {
     }
   );
 
-  const children = Array.from(Array(65).keys()).map((index) => ({
-    name: 'child',
-    data: {idx: index, foo: 'bar'},
-    queueName,
-  }));
   await flow.add({
     name: 'parent-job',
     queueName: parentQueueName,
     data: {},
-    children,
+    children: [
+      {name: 'child', data: {idx: 0, foo: 'bar'}, queueName},
+      {name: 'child', data: {idx: 1, foo: 'baz'}, queueName},
+      {name: 'child', data: {idx: 2, foo: 'qux'}, queueName},
+    ],
   });
 
   Arena(

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "bee-queue": "^1.4.0",
     "bull": "^3.22.6",
-    "bullmq": "^1.28.0",
+    "bullmq": "^1.33.0",
     "express": "^4.17.1",
     "redis-server": "^1.2.2"
   }

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "bee-queue": "^1.4.0",
     "bull": "^3.22.6",
-    "bullmq": "^1.33.0",
+    "bullmq": "^1.33.1",
     "express": "^4.17.1",
     "redis-server": "^1.2.2"
   }

--- a/src/server/views/dashboard/jobDetails.js
+++ b/src/server/views/dashboard/jobDetails.js
@@ -51,24 +51,12 @@ async function handler(req, res) {
     job.processedCount = processedCount;
     job.unprocessedCount = unprocessedCount;
 
-    console.log(processedCount, unprocessedCount);
     const {
       processed,
       unprocessed,
       nextProcessedCursor,
       nextUnprocessedCursor,
     } = await job.getDependencies({
-      processed: {
-        cursor: processedCursor,
-        count: processedCount,
-      },
-      unprocessed: {
-        cursor: unprocessedCursor,
-        count: unprocessedCount,
-      },
-    });
-    console.log(Object.keys(processed).length);
-    console.log({
       processed: {
         cursor: processedCursor,
         count: processedCount,

--- a/src/server/views/dashboard/jobDetails.js
+++ b/src/server/views/dashboard/jobDetails.js
@@ -45,9 +45,9 @@ async function handler(req, res) {
   if (queue.IS_BULLMQ) {
     job.parent = JobHelpers.getKeyProperties(job.parentKey);
     const processedCursor = parseInt(req.query.processedCursor, 10) || 0;
-    const processedCount = parseInt(req.query.processedCount, 10) || 50;
+    const processedCount = parseInt(req.query.processedCount, 10) || 25;
     const unprocessedCursor = parseInt(req.query.unprocessedCursor, 10) || 0;
-    const unprocessedCount = parseInt(req.query.unprocessedCount, 10) || 50;
+    const unprocessedCount = parseInt(req.query.unprocessedCount, 10) || 25;
     job.processedCount = processedCount;
     job.unprocessedCount = unprocessedCount;
 

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -145,6 +145,17 @@
   <div class="col-sm-12">
     <h5>Unprocessed Children</h5>
 
+    <nav aria-label="Unprocessed navigation">
+      <ul class="pagination">
+        <li><a
+            href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ this.id }}?unprocessedCursor={{ this.unprocessedCursor }}&amp;unprocessedCount={{ this.unprocessedCount }}"
+            aria-label="Previous">
+            <span aria-hidden="true">&raquo;</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+
     {{#each this.unprocessedChildren}}
     <a href="{{ ../basePath }}/{{ encodeURI ../queueHost }}/{{ encodeURI this.queueName }}/{{ this.id }}">
       <span class="label label-danger">{{ this.id }}</span>
@@ -158,6 +169,17 @@
 <div class="row">
   <div class="col-sm-12">
     <h5>Processed Children</h5>
+
+    <nav aria-label="Processed navigation">
+      <ul class="pagination">
+        <li><a
+            href="{{ basePath }}/{{ encodeURI queueHost }}/{{ encodeURI queueName }}/{{ this.id }}?processedCursor={{ this.processedCursor }}&amp;processedCount={{ this.processedCount }}"
+            aria-label="Previous">
+            <span aria-hidden="true">&raquo;</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
 
     {{#each this.processedChildren}}
     <a href="{{ ../basePath }}/{{ encodeURI ../queueHost }}/{{ encodeURI this.queueName }}/{{ this.id }}">


### PR DESCRIPTION
#### Changes Made
This PR adds pagination for children, since getDependencies has options to do it. Note: Pagination is working with cursors so we could only go from one side, we cannot go back. This is the only limitation because  of how those dependencies are saved in Redis.
#### Potential Risks
No potential risk.

#### Test Plan
1. Go to example directory.
2. Run npm run start:bullmq
3. Go to waiting-children state in parent queue
4. Select the parent job
5. Go to the perma link to see job details
6. You should see a button for children to >> go to the next children jobs. there is a min count of children that is 25 to be showed.
#### Checklist

- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
