### PR TITLE
Add children counters

### DIFF
--- a/src/server/views/dashboard/jobDetails.js
+++ b/src/server/views/dashboard/jobDetails.js
@@ -45,11 +45,14 @@ async function handler(req, res) {
   if (queue.IS_BULLMQ) {
     job.parent = JobHelpers.getKeyProperties(job.parentKey);
     const {processed, unprocessed} = await job.getDependencies();
+    const count = await job.getDependenciesCount();
     if (unprocessed && unprocessed.length) {
       job.unprocessedChildren = unprocessed.map((child) => {
         return JobHelpers.getKeyProperties(child);
       });
     }
+
+    job.countDependencies = count;
 
     if (processed) {
       const childrenKeys = Object.keys(processed);

--- a/src/server/views/partials/dashboard/jobDetails.hbs
+++ b/src/server/views/partials/dashboard/jobDetails.hbs
@@ -143,7 +143,7 @@
 {{#if this.unprocessedChildren }}
 <div class="row">
   <div class="col-sm-12">
-    <h5>Unprocessed Children</h5>
+    <h5>Unprocessed Children <span class="count">{{ this.countDependencies.unprocessed}}</span></h5>
 
     {{#each this.unprocessedChildren}}
     <a href="{{ ../basePath }}/{{ encodeURI ../queueHost }}/{{ encodeURI this.queueName }}/{{ this.id }}">
@@ -157,7 +157,7 @@
 {{#if this.processedChildren }}
 <div class="row">
   <div class="col-sm-12">
-    <h5>Processed Children</h5>
+    <h5>Processed Children <span class="count">{{ this.countDependencies.processed}}</span></h5>
 
     {{#each this.processedChildren}}
     <a href="{{ ../basePath }}/{{ encodeURI ../queueHost }}/{{ encodeURI this.queueName }}/{{ this.id }}">


### PR DESCRIPTION
#### Changes Made
This PR adds the counter of jobs for processed and unprocessed children into jobDetails logic and template.
#### Test Plan
1. Go to example directory.
2. Run npm run start:bullmq_with_flows
3. Go to waiting-children state in parent queue
4. Select the parent job
5. Go to the perma link to see job details
6. You should see the number of children for processed and unprocessed.
#### Checklist
- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.



