### PR TITLE
Use perma links on nodes tree

### DIFF
--- a/example/bullmq_with_flows.js
+++ b/example/bullmq_with_flows.js
@@ -80,7 +80,7 @@ async function main() {
           name: queueName,
 
           // User-readable display name for the host. Required.
-          hostId: 'Queue Server 1',
+          hostId: 'Server 1',
 
           // Queue type (Bull or Bullmq or Bee - default Bull).
           type: 'bullmq',
@@ -95,7 +95,7 @@ async function main() {
           name: parentQueueName,
 
           // User-readable display name for the host. Required.
-          hostId: 'Queue Server 1',
+          hostId: 'Server 1',
 
           // Queue type (Bull or Bullmq or Bee - default Bull).
           type: 'bullmq',
@@ -110,7 +110,7 @@ async function main() {
       flows: [
         {
           // User-readable display name for the host. Required.
-          hostId: 'Flow server 1',
+          hostId: 'Server 1',
 
           // Required for each flow definition.
           name: 'Connection name 1',
@@ -125,7 +125,7 @@ async function main() {
         },
         {
           // User-readable display name for the host. Required.
-          hostId: 'Flow server 2',
+          hostId: 'Server 1',
 
           // Required for each flow definition.
           name: 'Connection name 2',

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "bee-queue": "^1.4.0",
     "bull": "^3.22.6",
-    "bullmq": "^1.33.1",
+    "bullmq": "^1.34.0",
     "express": "^4.17.1",
     "redis-server": "^1.2.2"
   }

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -5,9 +5,20 @@ $(document).ready(() => {
     return string.charAt(0).toUpperCase() + string.slice(1);
   }
 
-  function formatToTreeView(flow) {
+  function encodeURI(url) {
+    if (typeof url !== 'string') {
+      return '';
+    }
+    return encodeURIComponent(url);
+  }
+
+  function formatToTreeView(flow, basePath, flowHost) {
     const {job, children} = flow;
-    const text = `${job.name} <span class="label label-default">${job.id}</span>`;
+    const text = `${job.name} <a href="${basePath}/${encodeURI(
+      flowHost
+    )}/${encodeURI(job.queueName)}/${
+      job.id
+    }"><span class="label label-default">${job.id}</span></a>`;
 
     if (children && children.length > 0) {
       return {
@@ -282,7 +293,7 @@ $(document).ready(() => {
       contentType: 'application/json',
     })
       .done((res) => {
-        const flowTree = formatToTreeView(res);
+        const flowTree = formatToTreeView(res, basePath, flowHost);
         alert('Flow successfully added!');
         localStorage.removeItem('arena:savedFlow');
         $('#tree').treeview({data: [flowTree]});

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -306,10 +306,10 @@ $(document).ready(() => {
 
   $('.js-search-flow').on('click', function (e) {
     e.preventDefault();
-    const queueName = $('.js-queue-input-search').val();
-    const jobId = $('.js-job-id-input-search').val();
-    const depth = $('.js-depth-input-search').val();
-    const maxChildren = $('.js-max-children-input-search').val();
+    const queueName = $('#queue-name-input-search').val();
+    const jobId = $('#job-id-input-search').val();
+    const depth = $('#depth-input-search').val();
+    const maxChildren = $('#max-children-input-search').val();
 
     const {flowHost, connectionName} = window.arenaInitialPayload;
 

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -5,29 +5,28 @@ $(document).ready(() => {
     return string.charAt(0).toUpperCase() + string.slice(1);
   }
 
-  function encodeURI(url) {
-    if (typeof url !== 'string') {
-      return '';
-    }
-    return encodeURIComponent(url);
-  }
-
-  function formatToTreeView(flow, basePath, flowHost) {
+  function formatToTreeView(flow, flowHost) {
     const {job, children} = flow;
-    const text = `${job.name} <a href="${basePath}/${encodeURI(
+    const text = `${job.name} <a href="${basePath}/${encodeURIComponent(
       flowHost
-    )}/${encodeURI(job.queueName)}/${
+    )}/${encodeURIComponent(job.queueName)}/${
       job.id
     }"><span class="label label-default">${job.id}</span></a>`;
+
+    const href = `${basePath}/${encodeURIComponent(
+      flowHost
+    )}/${encodeURIComponent(job.queueName)}/${job.id}`;
 
     if (children && children.length > 0) {
       return {
         text,
-        nodes: children.map((child) => formatToTreeView(child)),
+        // href,
+        nodes: children.map((child) => formatToTreeView(child, flowHost)),
       };
     } else {
       return {
         text,
+        // href,
       };
     }
   }
@@ -293,10 +292,10 @@ $(document).ready(() => {
       contentType: 'application/json',
     })
       .done((res) => {
-        const flowTree = formatToTreeView(res, basePath, flowHost);
+        const flowTree = formatToTreeView(res, flowHost);
         alert('Flow successfully added!');
         localStorage.removeItem('arena:savedFlow');
-        $('#tree').treeview({data: [flowTree]});
+        $('#tree').treeview({data: [flowTree], enableLinks: true});
         $('.js-tree').toggleClass('hide', false);
       })
       .fail((jqXHR) => {
@@ -324,9 +323,9 @@ $(document).ready(() => {
       contentType: 'application/json',
     })
       .done((res) => {
-        const flowTree = formatToTreeView(res);
+        const flowTree = formatToTreeView(res, flowHost);
         alert('Flow info successfully fetched!');
-        $('#tree').treeview({data: [flowTree]});
+        $('#tree').treeview({data: [flowTree], enableLinks: true});
         $('.js-tree').toggleClass('hide', false);
       })
       .fail((jqXHR) => {

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -20,13 +20,11 @@ $(document).ready(() => {
     if (children && children.length > 0) {
       return {
         text,
-        // href,
         nodes: children.map((child) => formatToTreeView(child, flowHost)),
       };
     } else {
       return {
         text,
-        // href,
       };
     }
   }

--- a/src/server/views/api/addFlow.js
+++ b/src/server/views/api/addFlow.js
@@ -1,3 +1,5 @@
+const flowHelpers = require('../helpers/flowHelpers');
+
 async function handler(req, res) {
   const {connectionName, flowHost} = req.params;
   const {data} = req.body;
@@ -8,9 +10,10 @@ async function handler(req, res) {
   if (!flow) return res.status(404).json({error: 'flow not found'});
 
   try {
-    const result = await Flows.set(flow, data);
+    const flowTree = await Flows.set(flow, data);
+    const processedFlow = flowHelpers.processFlow(flowTree);
 
-    return res.status(200).json(result);
+    return res.status(200).json(processedFlow);
   } catch (err) {
     return res.status(500).json({error: err.message});
   }

--- a/src/server/views/api/getFlow.js
+++ b/src/server/views/api/getFlow.js
@@ -1,3 +1,19 @@
+function processFlow(flow) {
+  const {job, children} = flow;
+  const queueName = job.queueName;
+
+  if (children && children.length > 0) {
+    return {
+      job: {...job, queueName},
+      children: children.map((child) => processFlow(child)),
+    };
+  } else {
+    return {
+      job: {...job, queueName},
+    };
+  }
+}
+
 async function handler(req, res) {
   const {connectionName, flowHost} = req.params;
   const {depth, jobId, maxChildren, queueName} = req.query;
@@ -11,7 +27,9 @@ async function handler(req, res) {
       depth: Number(depth),
       maxChildren: Number(maxChildren),
     });
-    return res.status(200).json(flowTree);
+    const processedFlow = processFlow(flowTree);
+    const {job} = flowTree;
+    return res.status(200).json(processedFlow);
   } catch (err) {
     return res.status(500).json({error: err.message});
   }

--- a/src/server/views/api/getFlow.js
+++ b/src/server/views/api/getFlow.js
@@ -1,18 +1,4 @@
-function processFlow(flow) {
-  const {job, children} = flow;
-  const queueName = job.queueName;
-
-  if (children && children.length > 0) {
-    return {
-      job: {...job, queueName},
-      children: children.map((child) => processFlow(child)),
-    };
-  } else {
-    return {
-      job: {...job, queueName},
-    };
-  }
-}
+const flowHelpers = require('../helpers/flowHelpers');
 
 async function handler(req, res) {
   const {connectionName, flowHost} = req.params;
@@ -27,8 +13,8 @@ async function handler(req, res) {
       depth: Number(depth),
       maxChildren: Number(maxChildren),
     });
-    const processedFlow = processFlow(flowTree);
-    const {job} = flowTree;
+    const processedFlow = flowHelpers.processFlow(flowTree);
+
     return res.status(200).json(processedFlow);
   } catch (err) {
     return res.status(500).json({error: err.message});

--- a/src/server/views/dashboard/templates/flowDetails.hbs
+++ b/src/server/views/dashboard/templates/flowDetails.hbs
@@ -17,36 +17,28 @@
           </div>
         </div>
         <div class="searchflowx hide">
-          <div class="row">
-            <div class="col-sm-4 ">
-              <h5>Queue Name</h5>
-            </div>
-            <div class="col-sm-2 ">
-              <input class="js-queue-input-search" type="text" name="queueNameInputSearch">
+          <div class="form-group row">
+            <label for="queue-name-input-search" class="col-sm-4 col-form-label">Queue Name</label>
+            <div class="col-sm-8">
+              <input type="text" class="form-control" id="queue-name-input-search" placeholder="Queue Name">
             </div>
           </div>
-          <div class="row">
-            <div class="col-sm-4 right-buffer">
-              <h5>Job Id</h5>
-            </div>
-            <div class="col-sm-2 right-buffer">
-              <input class="js-job-id-input-search" type="text" name="jobIdInputSearch">
+          <div class="form-group row">
+            <label for="job-id-input-search" class="col-sm-4 col-form-label">Job Id</label>
+            <div class="col-sm-8">
+              <input type="text" class="form-control" id="job-id-input-search" placeholder="Job Id">
             </div>
           </div>
-          <div class="row">
-            <div class="col-sm-4 right-buffer">
-              <h5>Tree depth</h5>
-            </div>
-            <div class="col-sm-2 right-buffer">
-              <input class="js-depth-input-search" type="text" name="depthInputSearch">
+          <div class="form-group row">
+            <label for="depth-input-search" class="col-sm-4 col-form-label">Tree Depth</label>
+            <div class="col-sm-8">
+              <input type="text" class="form-control" id="depth-input-search" placeholder="Tree Depth">
             </div>
           </div>
-          <div class="row">
-            <div class="col-sm-4 right-buffer">
-              <h5>Limit Children</h5>
-            </div>
-            <div class="col-sm-2 right-buffer">
-              <input class="js-max-children-input-search" type="text" name="maxChildrenInputSearch">
+          <div class="form-group row">
+            <label for="max-children-input-search" class="col-sm-4 col-form-label">Limit Children</label>
+            <div class="col-sm-8">
+              <input type="text" class="form-control" id="max-children-input-search" placeholder="Limit Children">
             </div>
           </div>
           <br />

--- a/src/server/views/helpers/flowHelpers.js
+++ b/src/server/views/helpers/flowHelpers.js
@@ -1,0 +1,19 @@
+const Helpers = {
+  processFlow: function (flow) {
+    const {job, children} = flow;
+    const queueName = job.queueName;
+
+    if (children && children.length > 0) {
+      return {
+        job: {...job, queueName},
+        children: children.map((child) => this.processFlow(child)),
+      };
+    } else {
+      return {
+        job: {...job, queueName},
+      };
+    }
+  },
+};
+
+module.exports = Helpers;


### PR DESCRIPTION
#### Changes Made
This PR adds perma links on tree view, so we can easily go to an specific job details page from tree view.
#### Potential Risks
No potential risks
#### Test Plan
1. Go to example directory
2. Run npm run start:bullmq_with_flows
3. Go to the first flow connection
4. Create a flow, for example using:
```
{
  "name": "parent-job",
    "queueName": "name_of_my_parent_queue",
    "data": {},
    "children": [
      {"name": "child","data": {"idx": 0, "fo": "bar"}, "queueName":"name_of_my_queue"}
    ]
}

```
5. You should see the tree view and if you click to the name of each node, you should go to that job detail
6. Also if you look for that flow using, same behaviour of perma links should work.
#### Checklist

- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
