### PR TITLE
Update how Redis URL is passed to Bull

### DIFF
--- a/src/server/queue/index.js
+++ b/src/server/queue/index.js
@@ -120,8 +120,14 @@ class Queues {
       if (queueConfig.createClient)
         options.createClient = queueConfig.createClient;
 
+      if (typeof options.redis === 'string') delete options.redis;
+
       const {Bull} = this._config;
-      queue = new Bull(name, options);
+      if (url) {
+        queue = new Bull(name, url, options);
+      } else {
+        queue = new Bull(name, options);
+      }
       queue.IS_BULL = true;
     }
 


### PR DESCRIPTION
#### Changes Made
Bull no longer allows passing the URL directly as the value of
`options.redis`. Instead, pass URL as a separate argument when present.

See https://github.com/OptimalBits/bull/issues/2118 for additional
context.

#### Potential Risks
Specifying the Redis URL under the `redis` key instead of `url` would have worked before's Bull's changes but this PR doesn't attempt to address that scenario.

#### Test Plan
Using the `url` config with the latest version of Bull should demonstrate the fix. This should also work on older versions of Bull, the way it was previously handled here only worked by accident.

#### Checklist

- [ ] <strike>I've increased test coverage</strike> there are no tests as far as I can see? Not sure what this is about
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
